### PR TITLE
fix(web): retirer le second formulaire prompt en bas de la landing

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -153,9 +153,7 @@ export default function LandingPage() {
   const [authed, setAuthed] = useState(false);
   const [navScrolled, setNavScrolled] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const ctaTextareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const ctaFileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setAuthed(Boolean(getToken()));
@@ -541,22 +539,6 @@ export default function LandingPage() {
               <GithubMark />
               {t("landingContributeCta")}
             </a>
-          </div>
-        </section>
-      </LandingReveal>
-
-      <LandingReveal>
-        <section className="lp-cta">
-          <div className="lp-cta-wash" aria-hidden />
-          <div className="lp-cta-inner">
-            <h2 className="lp-cta-title">{t("landingCtaTitle")}</h2>
-            <p className="lp-cta-sub">{t("landingCtaSub")}</p>
-            <LandingPromptBox
-              {...promptProps}
-              compact
-              textareaRef={ctaTextareaRef}
-              fileInputRef={ctaFileInputRef}
-            />
           </div>
         </section>
       </LandingReveal>


### PR DESCRIPTION
## Summary
- Suppression de la section \lp-cta\ (second \LandingPromptBox\ en bas de page)
- Nettoyage des refs \ctaTextareaRef\ / \ctaFileInputRef\`n
## Test plan
- [ ] Landing : un seul prompt dans le hero
- [ ] Pas de bloc CTA avec formulaire avant le footer

Made with [Cursor](https://cursor.com)