### PR TITLE
fix(web): URLs publish forge.rodiumai.io en prod

### DIFF
--- a/apps/web/.env.production.example
+++ b/apps/web/.env.production.example
@@ -1,5 +1,6 @@
 # Amplify (apps/web) — production
 NEXT_PUBLIC_API_URL=https://api-forge.rodiumai.io
+NEXT_PUBLIC_SITES_BASE_DOMAIN=forge.rodiumai.io
 NEXT_PUBLIC_S3_PUBLIC_BASE_URL=https://forge-uploads-prod.s3.eu-west-1.amazonaws.com
 NEXT_PUBLIC_RODIUM_USER_APP_URL=https://rodiumai.io
 

--- a/apps/web/components/builder/BuilderTopbar.tsx
+++ b/apps/web/components/builder/BuilderTopbar.tsx
@@ -22,6 +22,7 @@ import { Icon } from "@/components/ui/icon";
 import { LocaleSwitch, useI18n } from "@/lib/i18n/I18nProvider";
 import type { BuilderMode, ViewportMode } from "./types";
 import { PublishPopover } from "./PublishPopover";
+import { sitesUrlForSlug } from "@/lib/sites-url";
 
 type Props = {
   projectName: string;
@@ -92,7 +93,9 @@ export function BuilderTopbar({
 
   const previewExternalUrl = `${apiBase()}/preview/${projectId}/`;
   const published = Boolean(publishedAt);
-  const liveSiteUrl = published ? sitesUrl || (slug ? `http://${slug}.lvh.me:8080` : null) : null;
+  const liveSiteUrl = published
+    ? sitesUrl || (slug ? sitesUrlForSlug(slug) : null)
+    : null;
   const [openingDraft, setOpeningDraft] = useState(false);
 
   useEffect(() => {

--- a/apps/web/components/builder/OptionsPane.tsx
+++ b/apps/web/components/builder/OptionsPane.tsx
@@ -22,6 +22,7 @@ import { removeProject } from "@/lib/lists-cache";
 import { Icon } from "@/components/ui/icon";
 import { useI18n } from "@/lib/i18n/I18nProvider";
 import { SeoOptionsSection } from "@/components/builder/SeoOptionsSection";
+import { sitesBaseDomain, sitesScheme, sitesUrlForSlug } from "@/lib/sites-url";
 
 type OptionsSection = "general" | "environment" | "brand" | "seo" | "publishing" | "stats" | "danger";
 
@@ -384,14 +385,14 @@ export function OptionsPane({
               <label htmlFor="options-slug">{t("optionsProjectSlug")}</label>
               <p className="options-help">{t("optionsProjectSlugHelp")}</p>
               <div className="options-slug-row">
-                <span className="options-slug-prefix">https://</span>
+                <span className="options-slug-prefix">{sitesScheme()}://</span>
                 <input
                   id="options-slug"
                   value={slug}
                   onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-"))}
                   autoComplete="off"
                 />
-                <span className="options-slug-suffix">.lvh.me:8080</span>
+                <span className="options-slug-suffix">.{sitesBaseDomain()}</span>
               </div>
             </div>
             <div className="options-actions">
@@ -470,7 +471,7 @@ export function OptionsPane({
             <div className="options-stat-row">
               <span>{t("publishWebsiteUrl")}</span>
               <strong className="options-url">
-                {sitesUrl || (slug ? `http://${slug}.lvh.me:8080` : "—")}
+                {sitesUrl || (slug ? sitesUrlForSlug(slug) : "—")}
               </strong>
             </div>
             <p className="options-help">{t("optionsPublishHelp")}</p>

--- a/apps/web/components/builder/PublishPopover.tsx
+++ b/apps/web/components/builder/PublishPopover.tsx
@@ -19,6 +19,7 @@ import QRCode from "qrcode";
 import { Icon } from "@/components/ui/icon";
 import { useI18n } from "@/lib/i18n/I18nProvider";
 import { topProgressDone, topProgressStart } from "@/lib/top-progress";
+import { sitesBaseDomain, sitesHostLabel, sitesUrlForSlug } from "@/lib/sites-url";
 
 type Props = {
   projectId: string;
@@ -338,10 +339,11 @@ export function PublishPopover({
     };
   }, [open, hasPublished, url]);
 
-  const hostLabel = hasPublished && url
-    ? displayHost(url)
+  const effectiveUrl = url || sitesUrl || (slug ? sitesUrlForSlug(slug) : "");
+  const hostLabel = effectiveUrl
+    ? displayHost(effectiveUrl)
     : slug
-      ? `${slug}.lvh.me:8080`
+      ? sitesHostLabel(slug)
       : t("publishEmpty");
 
   // Publish is a single synchronous POST: phase labels are estimated from
@@ -400,7 +402,7 @@ export function PublishPopover({
 
           <div className="publish-section-label">
             <span>{t("publishWebsiteUrl")}</span>
-            <span className="publish-add-domain-muted">{t("publishDomainHint")}</span>
+            <span className="publish-add-domain-muted">{sitesBaseDomain()}</span>
           </div>
 
           <div className="publish-url-card">

--- a/apps/web/lib/sites-url.ts
+++ b/apps/web/lib/sites-url.ts
@@ -1,0 +1,36 @@
+/** Published site host — must stay aligned with API `sites_url_for_slug()`. */
+const LOCAL_SITES_BASE_DOMAIN = "lvh.me:8080";
+const PROD_SITES_BASE_DOMAIN = "forge.rodiumai.io";
+
+export function sitesBaseDomain(): string {
+  const fromEnv = process.env.NEXT_PUBLIC_SITES_BASE_DOMAIN?.trim();
+  if (fromEnv) return fromEnv.replace(/^\.+/, "");
+
+  if (typeof window !== "undefined") {
+    const host = window.location.hostname;
+    if (host === "forge.rodiumai.io" || host.endsWith(".forge.rodiumai.io")) {
+      return PROD_SITES_BASE_DOMAIN;
+    }
+  }
+
+  return LOCAL_SITES_BASE_DOMAIN;
+}
+
+export function sitesScheme(): "http" | "https" {
+  const domain = sitesBaseDomain();
+  if (domain.includes("lvh.me") || domain.includes("localhost")) return "http";
+  return "https";
+}
+
+export function sitesUrlForSlug(slug: string): string {
+  const normalized = slug.trim().toLowerCase();
+  if (!normalized) return "";
+  return `${sitesScheme()}://${normalized}.${sitesBaseDomain()}`;
+}
+
+/** Host (+ port) shown in publish UI before the first deploy. */
+export function sitesHostLabel(slug: string): string {
+  const normalized = slug.trim().toLowerCase();
+  if (!normalized) return "";
+  return `${normalized}.${sitesBaseDomain()}`;
+}


### PR DESCRIPTION
Remplace les fallbacks lvh.me par lib/sites-url.ts. NEXT_PUBLIC_SITES_BASE_DOMAIN=forge.rodiumai.io sur Amplify. API ECS deja OK.

Made with [Cursor](https://cursor.com)