### PR TITLE
fix(publish): le site publie herite du SEO du projet

### DIFF
--- a/apps/api/app/routers/publish.py
+++ b/apps/api/app/routers/publish.py
@@ -64,6 +64,8 @@ async def publish_now(
             str(project.id),
             project.slug,
             owner_user_id=str(user.id),
+            # Fallback title when the project index.html has no <title>.
+            title=project.name or "Forge app",
         )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)[:2000]) from exc

--- a/apps/api/app/services/publish_esm.py
+++ b/apps/api/app/services/publish_esm.py
@@ -35,6 +35,9 @@ async def transform_project_to_dir(project_id: str, out_dir: Path, *, title: str
             "files": source,
             "entry": "src/main.tsx",
             "title": title,
+            # SEO source of truth: the published head inherits title/metas/
+            # favicon from the project's index.html (written by the SEO editor).
+            "indexHtml": files.get("index.html", ""),
             # Project-declared dependencies ride into the published import map.
             "extraImports": extra_import_map(project_id),
         },

--- a/apps/api/runtime/cli-lib.mjs
+++ b/apps/api/runtime/cli-lib.mjs
@@ -10,6 +10,39 @@ import { toPublishJsPath } from "./resolve.mjs";
 import { DEFAULT_CDN_IMPORTS } from "./importmap.mjs";
 
 /**
+ * SEO head carried from the project's index.html into the published page.
+ *
+ * The publish HTML used to be generated from scratch: every published site
+ * shipped "<title>Forge app</title>" and the default favicon, silently
+ * discarding everything the SEO editor had written.
+ *
+ * @param {string} html project index.html
+ * @returns {{ title: string|null, tags: string[] }}
+ */
+export function extractSeoHead(html) {
+  const head = (String(html || "").match(/<head[^>]*>([\s\S]*?)<\/head>/i) || [])[1] || "";
+  const titleMatch = head.match(/<title>([\s\S]*?)<\/title>/i);
+  const title = titleMatch ? titleMatch[1].trim() : null;
+  const tags = [];
+  let m;
+  const metaRe = /<meta\b[^>]*\/?>/gi;
+  while ((m = metaRe.exec(head))) {
+    const tag = m[0];
+    // charset/viewport are owned by the publish shell.
+    if (/charset\s*=/i.test(tag) || /name=["']viewport["']/i.test(tag)) continue;
+    tags.push(tag);
+  }
+  const linkRe = /<link\b[^>]*\/?>/gi;
+  while ((m = linkRe.exec(head))) {
+    const tag = m[0];
+    if (/rel=["'][^"']*(icon|apple-touch-icon|canonical|manifest)[^"']*["']/i.test(tag)) {
+      tags.push(tag);
+    }
+  }
+  return { title: title || null, tags };
+}
+
+/**
  * @param {Record<string, string>} files
  * @param {string} entry
  * @param {"preview"|"publish"} mode

--- a/apps/api/runtime/cli.mjs
+++ b/apps/api/runtime/cli.mjs
@@ -5,7 +5,7 @@
  */
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { buildGraph } from "./cli-lib.mjs";
+import { buildGraph, extractSeoHead } from "./cli-lib.mjs";
 import { checkNamedExports } from "./export_check.mjs";
 import { importMapScriptTag } from "./importmap.mjs";
 
@@ -56,14 +56,21 @@ async function main() {
     process.exit(2);
   }
 
+  // The published head inherits the project's SEO (title, description, og/
+  // twitter metas, favicon, canonical) written by the SEO editor into the
+  // project index.html — instead of a hardcoded "Forge app" shell.
+  const seo = extractSeoHead(payload.indexHtml || files["index.html"] || "");
+  const title = seo.title || payload.title || "Forge app";
+  const seoTags = seo.tags.join("\n");
+  const hasIcon = /rel=["'][^"']*icon/i.test(seoTags);
+
   const indexHtml = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>${escapeHtml(payload.title || "Forge app")}</title>
-<link rel="icon" type="image/png" href="/favicon.png" />
-${importMapScriptTag(extraImports)}
+<title>${escapeHtml(title)}</title>
+${hasIcon ? "" : '<link rel="icon" type="image/png" href="/favicon.png" />\n'}${seoTags ? seoTags + "\n" : ""}${importMapScriptTag(extraImports)}
 <style>${css}</style>
 </head>
 <body>

--- a/apps/api/tests/test_publish_seo.py
+++ b/apps/api/tests/test_publish_seo.py
@@ -1,0 +1,58 @@
+"""Published sites must carry the project's SEO, not a hardcoded shell.
+
+Every published site used to ship "<title>Forge app</title>" and the default
+favicon: the publish CLI generated its index.html from scratch and never read
+the project's — where the SEO editor writes title/description/og/favicon.
+"""
+
+import asyncio
+import shutil
+
+import pytest
+
+from app.services.filesystem import write_file
+from app.services.publish_esm import transform_project_to_dir
+from app.services.scaffold import scaffold_vite_react
+
+needs_node = pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+
+SEO_INDEX = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/images/brand-icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bloom Studio</title>
+    <meta name="description" content="A small sanctuary for slow hours." />
+    <meta property="og:title" content="Bloom Studio" />
+  </head>
+  <body><div id="root"></div><script type="module" src="/src/main.js"></script></body>
+</html>
+"""
+
+
+@needs_node
+class TestPublishedSeo:
+    def test_published_head_inherits_the_project_seo(self, project, tmp_path):
+        scaffold_vite_react(project, "Demo")
+        write_file(project, "index.html", SEO_INDEX)
+        out = tmp_path / "dist"
+        asyncio.run(transform_project_to_dir(project, out, title="Fallback Name"))
+        html = (out / "index.html").read_text(encoding="utf-8")
+        assert "<title>Bloom Studio</title>" in html
+        assert 'name="description"' in html
+        assert "brand-icon.png" in html
+        assert "Forge app" not in html
+        # The default favicon must not shadow the project's own icon.
+        assert html.count("rel=") == html.count("rel=")  # sanity
+        assert '/favicon.png"' not in html
+
+    def test_project_name_is_the_fallback_title(self, project, tmp_path):
+        scaffold_vite_react(project, "Demo")
+        write_file(project, "index.html", "<html><head></head><body><div id='root'></div></body></html>")
+        out = tmp_path / "dist"
+        asyncio.run(transform_project_to_dir(project, out, title="Portfolio de Sarah"))
+        html = (out / "index.html").read_text(encoding="utf-8")
+        assert "<title>Portfolio de Sarah</title>" in html
+        # No project icon declared -> default favicon kept.
+        assert 'href="/favicon.png"' in html


### PR DESCRIPTION
## Summary
- Les sites publies recuperent title, metas, favicon et canonical depuis \index.html\ du projet
- Fallback sur le nom du projet si aucun \<title>\ dans le HTML source
- Test \	est_publish_seo.py\ pour valider le comportement

## Test plan
- [ ] Merger et redeployer l'API ECS
- [ ] Re-publier un projet (ex. site-view)
- [ ] Verifier titre, favicon et metas OG sur le site publie