### PR TITLE
chore: branche dev + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "refonte/**"]
+    branches: [main, dev, "refonte/**"]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Création de la branche `dev` comme branche de travail par défaut
- La CI s''exécute désormais sur les push vers `dev`
- Le deploy ECS/ECR reste déclenché uniquement sur `main` (après merge PR)

## Workflow à suivre
1. Travailler et pousser sur `dev`
2. Ouvrir une PR `dev` → `main`
3. Merger après CI verte → deploy prod automatique

## Test plan
- [x] Branche `dev` créée sur origin
- [x] CI configurée pour `dev`