### PR TITLE
fix(upload): uploads S3 prod + import fichier chat

### DIFF
--- a/apps/api/app/providers/objects.py
+++ b/apps/api/app/providers/objects.py
@@ -1,14 +1,36 @@
 from __future__ import annotations
 
+import re
+
 import boto3
 from botocore.config import Config
 
 from app.config import get_settings
 from app.errors import provider_not_configured
 
+_GENERIC_AWS_S3_ENDPOINT = re.compile(
+    r"^https?://s3(?:[.-][a-z0-9-]+)?\.amazonaws\.com/?$",
+    re.IGNORECASE,
+)
+
 
 def _resolve_static_credentials() -> tuple[str, str]:
     return get_settings().resolved_object_store_credentials()
+
+
+def _normalize_endpoint(endpoint: str | None) -> str | None:
+    """Drop generic regional S3 endpoints when using virtual-hosted buckets.
+
+    With ``addressing_style=virtual``, boto3 must resolve ``{bucket}.s3.{region}.amazonaws.com``
+    per bucket. Pinning ``endpoint_url`` to ``https://s3.eu-west-1.amazonaws.com`` triggers
+    ``PermanentRedirect`` on PutObject — the exact prod upload failure we saw in CloudWatch.
+    """
+    if not endpoint:
+        return None
+    s = get_settings()
+    if s.object_store_addressing == "virtual" and _GENERIC_AWS_S3_ENDPOINT.match(endpoint.rstrip("/")):
+        return None
+    return endpoint
 
 
 def _client(endpoint: str | None):
@@ -30,6 +52,7 @@ def _client(endpoint: str | None):
     if access and secret:
         kwargs["aws_access_key_id"] = access
         kwargs["aws_secret_access_key"] = secret
+    endpoint = _normalize_endpoint(endpoint)
     if endpoint:
         kwargs["endpoint_url"] = endpoint
     return boto3.client(**kwargs)

--- a/apps/api/tests/test_object_store.py
+++ b/apps/api/tests/test_object_store.py
@@ -7,20 +7,14 @@ def test_generic_aws_endpoint_dropped_for_virtual_addressing(monkeypatch):
     monkeypatch.setenv("OBJECT_STORE_ADDRESSING", "virtual")
     monkeypatch.setenv("OBJECT_STORE_ENDPOINT", "https://s3.eu-west-1.amazonaws.com")
     objects_module.reset_object_store()
-    assert (
-        objects_module._normalize_endpoint("https://s3.eu-west-1.amazonaws.com")
-        is None
-    )
+    assert objects_module._normalize_endpoint("https://s3.eu-west-1.amazonaws.com") is None
 
 
 def test_minio_endpoint_kept_for_path_addressing(monkeypatch):
     monkeypatch.setenv("OBJECT_STORE_ADDRESSING", "path")
     monkeypatch.setenv("OBJECT_STORE_ENDPOINT", "http://127.0.0.1:9000")
     objects_module.reset_object_store()
-    assert (
-        objects_module._normalize_endpoint("http://127.0.0.1:9000")
-        == "http://127.0.0.1:9000"
-    )
+    assert objects_module._normalize_endpoint("http://127.0.0.1:9000") == "http://127.0.0.1:9000"
 
 
 def test_bucket_virtual_host_endpoint_kept(monkeypatch):

--- a/apps/api/tests/test_object_store.py
+++ b/apps/api/tests/test_object_store.py
@@ -1,0 +1,30 @@
+"""Object store endpoint normalization (S3 virtual-hosted addressing)."""
+
+from app.providers import objects as objects_module
+
+
+def test_generic_aws_endpoint_dropped_for_virtual_addressing(monkeypatch):
+    monkeypatch.setenv("OBJECT_STORE_ADDRESSING", "virtual")
+    monkeypatch.setenv("OBJECT_STORE_ENDPOINT", "https://s3.eu-west-1.amazonaws.com")
+    objects_module.reset_object_store()
+    assert (
+        objects_module._normalize_endpoint("https://s3.eu-west-1.amazonaws.com")
+        is None
+    )
+
+
+def test_minio_endpoint_kept_for_path_addressing(monkeypatch):
+    monkeypatch.setenv("OBJECT_STORE_ADDRESSING", "path")
+    monkeypatch.setenv("OBJECT_STORE_ENDPOINT", "http://127.0.0.1:9000")
+    objects_module.reset_object_store()
+    assert (
+        objects_module._normalize_endpoint("http://127.0.0.1:9000")
+        == "http://127.0.0.1:9000"
+    )
+
+
+def test_bucket_virtual_host_endpoint_kept(monkeypatch):
+    monkeypatch.setenv("OBJECT_STORE_ADDRESSING", "virtual")
+    endpoint = "https://forge-uploads-prod.s3.eu-west-1.amazonaws.com"
+    objects_module.reset_object_store()
+    assert objects_module._normalize_endpoint(endpoint) == endpoint

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1657,9 +1657,11 @@ html:has(.builder) body {
   color: inherit;
 }
 
-.builder-plus-label:disabled {
+.builder-plus-label:disabled,
+.builder-plus-label.is-disabled {
   opacity: 0.55;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .builder-connector-picker {

--- a/apps/web/app/projects/[id]/page.tsx
+++ b/apps/web/app/projects/[id]/page.tsx
@@ -6,6 +6,7 @@ import {
   FormEvent,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react";
@@ -301,6 +302,7 @@ export default function ProjectPage() {
   const streamingRunIdRef = useRef<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileInputId = useId();
   const bootSentRef = useRef(false);
   const bootPromptRef = useRef<string | null>(initialBoot);
   const chatRetryRef = useRef<ChatRetryAction | null>(null);
@@ -798,13 +800,6 @@ export default function ProjectPage() {
     addFiles(list);
   }
 
-  function openFilePicker() {
-    const input = fileInputRef.current;
-    if (!input || composerInputLocked) return;
-    input.value = "";
-    input.click();
-  }
-
   function removeAttachment(id: string) {
     setAttachments((prev) => {
       const target = prev.find((item) => item.id === id);
@@ -1171,8 +1166,17 @@ export default function ProjectPage() {
           return prev.filter((a) => !(a.source === "local" && a.kind === "image"));
         });
         if (fileInputRef.current) fileInputRef.current.value = "";
+        // Show the SERVER error verbatim when there is one (S3 denied, quota,
+        // 503 object store…) — only true browser-level network failures get
+        // the generic "check your connection" fallback. friendlyStreamError
+        // would also swallow server messages containing "timeout".
+        const raw = err instanceof Error ? err.message : String(err || "");
+        const isBrowserNetworkFailure =
+          /failed to fetch|network request failed|networkerror|load failed/i.test(raw) || !raw.trim();
         pushChatError(
-          friendlyStreamError(err, t("attachmentUploadFailed"), t("rodiumSessionExpired")),
+          isBrowserNetworkFailure
+            ? t("attachmentUploadFailed")
+            : friendlyStreamError(err, raw, t("rodiumSessionExpired")),
           null,
         );
         return;
@@ -2020,6 +2024,7 @@ export default function ProjectPage() {
                       files never arrived — drag & drop worked fine). */}
                   <input
                     ref={fileInputRef}
+                    id={fileInputId}
                     type="file"
                     className="landing-import-input"
                     multiple
@@ -2027,14 +2032,14 @@ export default function ProjectPage() {
                     onChange={onFilesSelected}
                     tabIndex={-1}
                     aria-hidden
+                    disabled={composerInputLocked}
                   />
-                  <button
-                    type="button"
-                    className="builder-plus-label"
+                  <label
+                    htmlFor={composerInputLocked ? undefined : fileInputId}
+                    className={`builder-plus-label${composerInputLocked ? " is-disabled" : ""}`}
                     title={t("importHint")}
                     aria-label={t("importAria")}
-                    disabled={composerInputLocked}
-                    onClick={openFilePicker}
+                    aria-disabled={composerInputLocked}
                   >
                     <span className="builder-plus">
                       <Icon icon={Plus} className="ui-icon-md" />
@@ -2044,7 +2049,7 @@ export default function ProjectPage() {
                         </span>
                       ) : null}
                     </span>
-                  </button>
+                  </label>
                   {working ? (
                     <button
                       type="button"

--- a/apps/web/lib/prompt-upload.ts
+++ b/apps/web/lib/prompt-upload.ts
@@ -45,7 +45,17 @@ export async function uploadPromptAttachments(
     }
     if (!res.ok) {
       const detail = await res.text().catch(() => res.statusText);
-      throw new Error(detail || "Upload failed");
+      let message = detail || "Upload failed";
+      try {
+        const parsed = JSON.parse(detail) as { detail?: string | { msg?: string }[] };
+        if (typeof parsed.detail === "string") message = parsed.detail;
+        else if (Array.isArray(parsed.detail) && parsed.detail[0]?.msg) {
+          message = parsed.detail.map((d) => d.msg).filter(Boolean).join("; ");
+        }
+      } catch {
+        /* keep raw body */
+      }
+      throw new Error(message);
     }
     const data = (await res.json()) as UploadResponse;
     const durablePreview =


### PR DESCRIPTION
## Summary
- **Upload prod** : corrige `PermanentRedirect` S3 (endpoint `s3.eu-west-1.amazonaws.com` + addressing `virtual` incompatible)
- **Composer** : bouton `+` via `<label htmlFor>` (plus fiable que `input.click()` programmatique)
- **Erreurs** : message API brut (ex. erreur S3) au lieu du generique « check your connection »

## Test plan
- [x] `pytest tests/test_object_store.py`
- [ ] Apres deploy : import image < 200 Ko dans le chat builder
- [ ] Verifier chips fichiers apres clic sur +