### PR TITLE
fix(upload): corriger handler except + picker chat projet

### DIFF
--- a/apps/api/app/routers/files.py
+++ b/apps/api/app/routers/files.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from app.auth import get_current_user
 from app.config import get_settings
 from app.db import get_db
-from app.errors import provider_not_configured
+from app.errors import SitesError
 from app.i18n import resolve_locale, t
 from app.models import Project, User
 from app.providers.objects import get_object_store
@@ -399,10 +399,10 @@ async def upload_project_image(
             filename=safe,
             content_type=content_type or "application/octet-stream",
         )
-    except provider_not_configured as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except SitesError:
+        raise
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)[:300]) from exc
+        raise HTTPException(status_code=500, detail=str(exc)[:500]) from exc
     name = asset_display_name(row.object_key)
     return FileUploadResponse(
         object_id=str(row.id),

--- a/apps/api/tests/test_files_upload.py
+++ b/apps/api/tests/test_files_upload.py
@@ -1,0 +1,14 @@
+"""Upload endpoint error handling."""
+
+import ast
+from pathlib import Path
+
+
+def test_upload_project_image_does_not_catch_provider_factory():
+    source = Path(__file__).resolve().parents[1] / "app" / "routers" / "files.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        if isinstance(node.type, ast.Name) and node.type.id == "provider_not_configured":
+            raise AssertionError("upload must catch SitesError, not provider_not_configured() factory")

--- a/apps/web/app/projects/[id]/page.tsx
+++ b/apps/web/app/projects/[id]/page.tsx
@@ -6,7 +6,6 @@ import {
   FormEvent,
   useCallback,
   useEffect,
-  useId,
   useRef,
   useState,
 } from "react";
@@ -302,7 +301,6 @@ export default function ProjectPage() {
   const streamingRunIdRef = useRef<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const fileInputId = useId();
   const bootSentRef = useRef(false);
   const bootPromptRef = useRef<string | null>(initialBoot);
   const chatRetryRef = useRef<ChatRetryAction | null>(null);
@@ -793,11 +791,19 @@ export default function ProjectPage() {
   }
 
   function onFilesSelected(e: ChangeEvent<HTMLInputElement>) {
-    const list = e.target.files;
-    // Always clear so selecting the same file again still fires onChange.
+    // Snapshot before clearing — FileList is live; resetting the input first
+    // empties it in Chromium (picker works, drag & drop unaffected).
+    const list = Array.from(e.target.files || []);
     e.target.value = "";
-    if (!list?.length) return;
+    if (!list.length) return;
     addFiles(list);
+  }
+
+  function openFilePicker() {
+    const input = fileInputRef.current;
+    if (!input || composerInputLocked) return;
+    input.value = "";
+    input.click();
   }
 
   function removeAttachment(id: string) {
@@ -1173,12 +1179,7 @@ export default function ProjectPage() {
         const raw = err instanceof Error ? err.message : String(err || "");
         const isBrowserNetworkFailure =
           /failed to fetch|network request failed|networkerror|load failed/i.test(raw) || !raw.trim();
-        pushChatError(
-          isBrowserNetworkFailure
-            ? t("attachmentUploadFailed")
-            : friendlyStreamError(err, raw, t("rodiumSessionExpired")),
-          null,
-        );
+        pushChatError(isBrowserNetworkFailure ? t("attachmentUploadFailed") : raw.slice(0, 500), null);
         return;
       }
 
@@ -2024,7 +2025,6 @@ export default function ProjectPage() {
                       files never arrived — drag & drop worked fine). */}
                   <input
                     ref={fileInputRef}
-                    id={fileInputId}
                     type="file"
                     className="landing-import-input"
                     multiple
@@ -2032,14 +2032,14 @@ export default function ProjectPage() {
                     onChange={onFilesSelected}
                     tabIndex={-1}
                     aria-hidden
-                    disabled={composerInputLocked}
                   />
-                  <label
-                    htmlFor={composerInputLocked ? undefined : fileInputId}
-                    className={`builder-plus-label${composerInputLocked ? " is-disabled" : ""}`}
+                  <button
+                    type="button"
+                    className="builder-plus-label"
                     title={t("importHint")}
                     aria-label={t("importAria")}
-                    aria-disabled={composerInputLocked}
+                    disabled={composerInputLocked}
+                    onClick={openFilePicker}
                   >
                     <span className="builder-plus">
                       <Icon icon={Plus} className="ui-icon-md" />
@@ -2049,7 +2049,7 @@ export default function ProjectPage() {
                         </span>
                       ) : null}
                     </span>
-                  </label>
+                  </button>
                   {working ? (
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
- Corrige `except provider_not_configured` dans `files.py` (factory, pas Exception) qui provoquait un TypeError 500 sur chaque upload image
- Snapshot `FileList` avant reset de l input sur la page projet (bouton +)
- Affiche l erreur API brute côté UI au lieu du message générique masqué

## Test plan
- [ ] Upload image depuis accueil dashboard
- [ ] Upload image depuis page projet (bouton + et drag & drop)
- [ ] Vérifier logs ECS sans TypeError sur upload