### PR TITLE
fix(assets): materialiser uploads privés en /images/

### DIFF
--- a/apps/api/app/routers/preview.py
+++ b/apps/api/app/routers/preview.py
@@ -6,6 +6,7 @@ orphan reaper was a no-op on Windows. The runner needs no process at all: the
 browser receives the source bundle over postMessage and transforms it in-page.
 """
 
+import contextlib
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -20,6 +21,7 @@ from app.i18n import resolve_locale, t
 from app.models import Project, User
 from app.schemas import PreviewStatus
 from app.services import preview_babel
+from app.services.asset_storage import repair_private_upload_urls_in_project
 
 router = APIRouter(tags=["preview"])
 
@@ -48,6 +50,11 @@ def _project_extra_imports(project_id: str) -> dict[str, str]:
         return extra_import_map(project_id)
     except Exception:
         return {}
+
+
+def _repair_private_upload_urls(db: Session, project_id: UUID) -> None:
+    with contextlib.suppress(Exception):
+        repair_private_upload_urls_in_project(db, project_id)
 
 
 def _status(project: Project, *, running: bool) -> PreviewStatus:
@@ -84,6 +91,7 @@ def source_bundle(
     db: Session = Depends(get_db),
 ) -> SourceBundle:
     _owned(db, user, project_id, resolve_locale(request))
+    _repair_private_upload_urls(db, project_id)
     files = preview_babel.collect_project_source_files(str(project_id))
     return SourceBundle(
         entry="src/main.tsx",
@@ -107,6 +115,7 @@ def draft_page(
     a new tab" target; auth rides the `?access_token=` query support.
     """
     project = _owned(db, user, project_id, resolve_locale(request))
+    _repair_private_upload_urls(db, project_id)
     files = preview_babel.collect_project_source_files(str(project_id))
     # Root-path images (/images/x.png) resolve through the authenticated
     # project-public endpoint; same-origin here, so a relative base works.
@@ -131,6 +140,7 @@ def preview_start(
 ) -> PreviewStatus:
     project = _owned(db, user, project_id, resolve_locale(request))
     preview_babel.ensure_babel_project_layout(str(project_id))
+    _repair_private_upload_urls(db, project_id)
     preview_babel.mark_babel_preview_ready(str(project_id))
     project.preview_running = True
     project.preview_port = 0

--- a/apps/api/app/services/asset_storage.py
+++ b/apps/api/app/services/asset_storage.py
@@ -90,18 +90,64 @@ def get_project_asset_by_public_url(db: Session, project_id: UUID, public_url: s
     )
 
 
+_KNOWN_UPLOAD_BUCKETS = (
+    "forge-uploads",
+    "forge-uploads-prod",
+    "rodiumai-forge-uploads-prod",
+)
+
+
 def is_private_upload_url(url: str) -> bool:
     """True when `url` points at our private uploads bucket (never usable as img src)."""
     value = (url or "").strip()
     if not value.startswith(("http://", "https://")):
         return False
     settings = get_settings()
-    bucket = (settings.bucket_uploads or settings.aws_s3_bucket or "").strip()
-    if not bucket:
-        return False
-    # Path-style: http://host:9000/forge-uploads/key
-    # Virtual-style: http://forge-uploads.host/key
-    return f"/{bucket}/" in value or value.startswith((f"http://{bucket}.", f"https://{bucket}."))
+    buckets = {
+        *(b.strip() for b in _KNOWN_UPLOAD_BUCKETS),
+        (settings.bucket_uploads or "").strip(),
+        (settings.aws_s3_bucket or "").strip(),
+    }
+    buckets = {b for b in buckets if b}
+    for bucket in buckets:
+        # Path-style: http://host:9000/forge-uploads/key
+        # Virtual-style: https://rodiumai-forge-uploads-prod.s3.region.amazonaws.com/key
+        if f"/{bucket}/" in value or value.startswith((f"http://{bucket}.", f"https://{bucket}.")):
+            return True
+    return False
+
+
+def repair_private_upload_urls_in_project(db: Session, project_id: UUID) -> int:
+    """Rewrite private object-store URLs in project sources to `/images/...` paths."""
+    import re
+
+    from app.services.filesystem import list_files, read_file, write_file
+
+    replacements = 0
+    for path in list_files(str(project_id)):
+        if not path.endswith((".tsx", ".ts", ".jsx", ".js", ".html", ".css", ".md", ".vue")):
+            continue
+        try:
+            content = read_file(str(project_id), path)
+        except Exception:
+            continue
+        new_content = content
+        for url in set(re.findall(r"https?://[^\s\"'`)<>]+", content)):
+            if not is_private_upload_url(url):
+                continue
+            row = get_project_asset_by_public_url(db, project_id, url)
+            if row is None:
+                continue
+            try:
+                web_path = materialize_asset_to_public(db, project_id, row.id)
+            except Exception:
+                continue
+            if url in new_content:
+                new_content = new_content.replace(url, web_path)
+                replacements += 1
+        if new_content != content:
+            write_file(str(project_id), path, new_content)
+    return replacements
 
 
 def materialize_asset_to_public(db: Session, project_id: UUID, object_id: UUID) -> str:

--- a/apps/api/app/services/attachments.py
+++ b/apps/api/app/services/attachments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -12,7 +13,12 @@ import httpx
 from sqlalchemy.orm import Session
 
 from app.models import StoredObject
-from app.services.asset_storage import asset_display_name
+from app.services.asset_storage import (
+    asset_display_name,
+    is_private_upload_url,
+    materialize_asset_to_public,
+    repair_private_upload_urls_in_project,
+)
 from app.services.filesystem import project_dir
 
 _IMAGE_MARKER_RE = re.compile(
@@ -43,8 +49,9 @@ REFERENCE_VISION_INSTRUCTION = (
 
 ASSET_VISION_INSTRUCTION = (
     "This is an uploaded site asset (logo/icon/image). "
-    "Use the exact CDN url: from the markers in generated code "
-    '(<img src="..."> or CSS background-image). '
+    "Use the relative path from the markers (e.g. /images/...) in generated code "
+    '(<img src="/images/..."> or CSS url(/images/...)). '
+    "Never use raw S3 or object-store URLs — they are private and return AccessDenied. "
     "Do NOT generate a new image. Do NOT use a placeholder path."
 )
 
@@ -244,6 +251,53 @@ def _marker_intents(user_text: str) -> list[str]:
     return [m.group(1).lower() for m in _INTENT_IN_MARKER_RE.finditer(user_text or "")]
 
 
+def _intent_for_marker(marker: str) -> str:
+    intent_m = _INTENT_IN_MARKER_RE.search(marker)
+    return intent_m.group(1).lower() if intent_m else "reference"
+
+
+def materialize_asset_markers(db: Session, project_id: str, user_text: str) -> str:
+    """For asset-intent uploads, copy bytes into public/images/ and rewrite marker URLs."""
+    text = user_text or ""
+    if not db or not _IMAGE_MARKER_RE.search(text):
+        return text
+
+    try:
+        pid = UUID(project_id)
+    except ValueError:
+        return text
+
+    def replacer(match: re.Match[str]) -> str:
+        marker = match.group(0)
+        if _intent_for_marker(marker) != "asset":
+            return marker
+        obj_m = _OBJECT_IN_MARKER_RE.search(marker)
+        if not obj_m:
+            return marker
+        try:
+            oid = UUID(obj_m.group(1).strip())
+        except ValueError:
+            return marker
+        try:
+            web_path = materialize_asset_to_public(db, pid, oid)
+        except Exception:
+            return marker
+
+        updated = marker
+        replaced = False
+        for pat in (_URL_IN_MARKER_RE, _PUBLIC_IN_MARKER_RE):
+            m = pat.search(updated)
+            if m and is_private_upload_url(m.group(1).strip()):
+                updated = pat.sub(f"| url:{web_path}", updated, count=1)
+                replaced = True
+                break
+        if not replaced:
+            updated = updated[:-1] + f" | url:{web_path}]"
+        return updated
+
+    return _IMAGE_MARKER_RE.sub(replacer, text)
+
+
 def vision_instruction_for_message(user_text: str) -> str | None:
     """Background-only instructions for attached images (never shown in chat UI)."""
     if not _IMAGE_MARKER_RE.search(user_text or ""):
@@ -279,6 +333,11 @@ async def enrich_user_message_with_vision(
 
     Vision/asset instructions are injected here (LLM-only), not stored in chat UI text.
     """
+    if db is not None:
+        with contextlib.suppress(Exception):
+            repair_private_upload_urls_in_project(db, UUID(project_id))
+        user_text = materialize_asset_markers(db, project_id, user_text)
+
     instruction = vision_instruction_for_message(user_text)
     text_for_llm = user_text
     if instruction and instruction not in (user_text or ""):

--- a/apps/api/tests/test_attachment_asset_materialize.py
+++ b/apps/api/tests/test_attachment_asset_materialize.py
@@ -1,0 +1,54 @@
+"""Asset-intent markers must materialize to /images/... — never raw private S3 URLs."""
+
+import io
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import asset_storage
+from app.services.attachments import materialize_asset_markers
+
+
+class _FakeStore:
+    bucket_uploads = "rodiumai-forge-uploads-prod"
+
+    class internal:
+        @staticmethod
+        def get_object(Bucket: str, Key: str) -> dict:
+            return {"Body": io.BytesIO(b"\x89PNG fake")}
+
+
+@pytest.fixture
+def materialize_setup(project, monkeypatch):
+    object_id = uuid.uuid4()
+    project_id = str(uuid.uuid4())
+    row = SimpleNamespace(id=object_id, object_key=f"forge/u/p/{uuid.uuid4()}-logo.png")
+    monkeypatch.setattr(asset_storage, "get_project_asset", lambda db, pid, oid: row)
+    monkeypatch.setattr("app.providers.objects.get_object_store", lambda: _FakeStore())
+    return project_id, object_id
+
+
+def test_materialize_asset_markers_rewrites_private_s3_url(materialize_setup):
+    project, object_id = materialize_setup
+    s3 = "https://rodiumai-forge-uploads-prod.s3.eu-west-1.amazonaws.com/forge/u/p/x-logo.png"
+    text = (
+        f"[Image attached: logo.png | url:{s3} | object:{object_id} | intent:asset]"
+    )
+    out = materialize_asset_markers(object(), project, text)
+    assert s3 not in out
+    assert "/images/" in out
+    assert f"object:{object_id}" in out
+
+
+def test_reference_intent_marker_is_unchanged(materialize_setup):
+    project, object_id = materialize_setup
+    s3 = "https://rodiumai-forge-uploads-prod.s3.eu-west-1.amazonaws.com/forge/u/p/x.png"
+    text = f"[Reference screenshot: mock.png | url:{s3} | object:{object_id} | intent:reference]"
+    assert materialize_asset_markers(object(), project, text) == text
+
+
+def test_is_private_upload_url_detects_prod_bucket():
+    url = "https://rodiumai-forge-uploads-prod.s3.eu-west-1.amazonaws.com/forge/a/b.png"
+    assert asset_storage.is_private_upload_url(url)
+    assert not asset_storage.is_private_upload_url("https://cdn.example.com/a.png")

--- a/apps/web/components/DesignCharterSlideover.tsx
+++ b/apps/web/components/DesignCharterSlideover.tsx
@@ -160,11 +160,9 @@ export function DesignCharterSlideover({ projectId, open, onClose }: Props) {
     setSaved(false);
     try {
       let logo_object_id: string | null = null;
-      let logo_url: string | null = null;
       if (logoFile) {
         const uploaded = await uploadLogo(logoFile);
         logo_object_id = uploaded.object_id;
-        logo_url = uploaded.public_url;
       }
       const res = await api<{ markdown: string; brief: string; logo_path?: string | null }>(
         `/projects/${projectId}/design-charter`,
@@ -173,7 +171,6 @@ export function DesignCharterSlideover({ projectId, open, onClose }: Props) {
           body: JSON.stringify({
             brief: brief.trim() || "Generate a complete graphic charter from the brand logo.",
             logo_object_id,
-            logo_url,
             logo_path: existingLogoPath,
           }),
         },

--- a/apps/web/components/PromptFileChips.tsx
+++ b/apps/web/components/PromptFileChips.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { FileText, X } from "lucide-react";
 import { Icon } from "@/components/ui/icon";
-import { assetContentUrl } from "@/lib/asset-url";
+import { assetContentUrl, isPrivateUploadUrl } from "@/lib/asset-url";
 import { useI18n } from "@/lib/i18n/I18nProvider";
 import {
   attachmentName,
@@ -29,7 +29,7 @@ function resolveChipThumb(
     if (durable) return durable;
   }
   const preview = attachmentPreviewUrl(item);
-  if (preview && !preview.includes("localhost:9000/forge-uploads")) {
+  if (preview && !isPrivateUploadUrl(preview)) {
     return preview;
   }
   // Local blob previews still OK.

--- a/apps/web/components/UserMessageBody.tsx
+++ b/apps/web/components/UserMessageBody.tsx
@@ -3,7 +3,7 @@
 import { FileText } from "lucide-react";
 import { Icon } from "@/components/ui/icon";
 import { FileTypeIcon } from "@/components/builder/file-icons";
-import { assetContentUrl } from "@/lib/asset-url";
+import { assetContentUrl, isPrivateUploadUrl } from "@/lib/asset-url";
 import {
   parseUserMessageContent,
   type MessageAttachment,
@@ -28,7 +28,7 @@ function resolveThumbSrc(
   }
   // Prefer durable HTTP URLs over ephemeral blob: after refresh blobs die.
   const url = file.publicUrl || file.publicPath;
-  if (url && /^https?:\/\//i.test(url) && !url.includes("localhost:9000/forge-uploads")) {
+  if (url && /^https?:\/\//i.test(url) && !isPrivateUploadUrl(url)) {
     return url;
   }
   if (file.previewUrl && !file.previewUrl.startsWith("blob:")) {

--- a/apps/web/lib/asset-url.ts
+++ b/apps/web/lib/asset-url.ts
@@ -1,5 +1,17 @@
 import { apiBase, getToken } from "@/lib/api";
 
+/** Private uploads bucket URLs (S3/MinIO) — never usable as <img src>. */
+export function isPrivateUploadUrl(url: string | null | undefined): boolean {
+  const value = (url || "").trim();
+  if (!value.startsWith("http://") && !value.startsWith("https://")) return false;
+  return (
+    /localhost:9000\/forge-uploads\//i.test(value) ||
+    /https?:\/\/(?:forge-uploads(?:-prod)?|rodiumai-forge-uploads-prod)\./i.test(value) ||
+    /\/forge-uploads(?:-prod)?\//i.test(value) ||
+    /\/rodiumai-forge-uploads-prod\//i.test(value)
+  );
+}
+
 /** Durable authenticated URL for chat thumbs (<img src>). */
 export function assetContentUrl(projectId: string, objectId: string): string | null {
   if (!projectId || !objectId) return null;

--- a/infra/aws/iam/rodiumai-ecs-task-role-policy.json
+++ b/infra/aws/iam/rodiumai-ecs-task-role-policy.json
@@ -1,0 +1,50 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::rodiumai-media-prod",
+        "arn:aws:s3:::rodiumai-media-prod/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::forge-assets-prod",
+        "arn:aws:s3:::forge-assets-prod/*",
+        "arn:aws:s3:::forge-runtime-prod",
+        "arn:aws:s3:::forge-runtime-prod/*",
+        "arn:aws:s3:::rodiumai-forge-uploads-prod",
+        "arn:aws:s3:::rodiumai-forge-uploads-prod/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ses:SendEmail",
+        "ses:SendRawEmail"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": "arn:aws:secretsmanager:eu-west-1:330990434320:secret:rodiumai/*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Le bucket `rodiumai-forge-uploads-prod` est privé : les URLs S3 directes renvoient AccessDenied dans le navigateur
- Materialisation automatique des assets (intent:asset) vers `public/images/` avant envoi au LLM
- Réparation des URLs S3 déjà présentes dans le code source au chargement preview/chat
- UI : ne plus utiliser les URLs S3 privées comme src d image (proxy API authentifié)

## Test plan
- [ ] Upload image dans un projet, vérifier preview (src `/images/...` pas S3)
- [ ] Projet existant avec URL S3 cassée : recharger preview → image réparée
- [ ] Chat : miniature visible via proxy API