### PR TITLE
fix(preview): routing draft + basename BrowserRouter

### DIFF
--- a/apps/api/app/routers/preview.py
+++ b/apps/api/app/routers/preview.py
@@ -119,7 +119,10 @@ def draft_page(
     files = preview_babel.collect_project_source_files(str(project_id))
     # Root-path images (/images/x.png) resolve through the authenticated
     # project-public endpoint; same-origin here, so a relative base works.
-    assets: dict[str, str] = {"base": f"/projects/{project_id}/public"}
+    assets: dict[str, str] = {
+        "base": f"/projects/{project_id}/public",
+        "routerBase": f"/projects/{project_id}/draft",
+    }
     token = request.query_params.get("access_token")
     if token:
         assets["token"] = token

--- a/apps/api/app/services/preview_babel.py
+++ b/apps/api/app/services/preview_babel.py
@@ -90,8 +90,8 @@ def render_runner_shell(
 </head>
 <body>
   <div id="root"></div>
-  <script src="/runner/bridge.js?v=nav4"></script>
-  <script type="module" src="/runner/runner.js?v=nav4"></script>
+  <script src="/runner/bridge.js?v=nav5"></script>
+  <script type="module" src="/runner/runner.js?v=nav5"></script>
 </body>
 </html>
 """

--- a/apps/api/runtime/public/bridge.js
+++ b/apps/api/runtime/public/bridge.js
@@ -48,6 +48,23 @@
     }
   })();
 
+  /** /runner or /projects/{uuid}/draft — keeps BrowserRouter inside the shell. */
+  function getPreviewShellBase() {
+    if (typeof window.__FORGE_PREVIEW_SHELL_BASE__ === "string" && window.__FORGE_PREVIEW_SHELL_BASE__) {
+      return window.__FORGE_PREVIEW_SHELL_BASE__;
+    }
+    var pathname = window.location.pathname || "";
+    var draft = pathname.match(/^(\/projects\/[0-9a-f-]{36}\/draft)\/?/i);
+    if (draft) return draft[1];
+    if (/^\/runner\/?/i.test(pathname)) return "/runner";
+    return "";
+  }
+
+  function shellBasePrefix() {
+    var base = getPreviewShellBase();
+    return base ? base.replace(/\/+$/, "") : "";
+  }
+
   function post(payload) {
     if (!PARENT_ORIGIN) return;
     try {
@@ -542,6 +559,12 @@
       if (rest) return "/" + rest.toLowerCase();
       return "/";
     }
+    var draft = pathname.match(/^\/projects\/[0-9a-f-]{36}\/draft\/?(.*)$/i);
+    if (draft) {
+      var draftRest = (draft[1] || "").replace(/\/+$/, "").split("/")[0];
+      if (draftRest) return "/" + draftRest.toLowerCase();
+      return "/";
+    }
     var seg = pathname.replace(/\/+$/, "") || "/";
     if (seg === "/" || /^\/runner$/i.test(seg)) return "/";
     return seg.toLowerCase();
@@ -759,7 +782,8 @@
     var pageKey = normalized === "/" ? "" : normalized.replace(/^\//, "");
     var targetHash = pageKey ? "#" + pageKey : "";
     var pathname = window.location.pathname || "/";
-    var onRunner = /^\/runner\/?/i.test(pathname);
+    var shellBase = getPreviewShellBase();
+    var onPreviewShell = Boolean(shellBase);
 
     function setPreviewHash(nextKey) {
       var current = (window.location.hash || "").replace(/^#/, "");
@@ -771,7 +795,7 @@
         window.location.hash = nextKey;
         return;
       }
-      var keep = (onRunner ? pathname : "/runner/") + (window.location.search || "");
+      var keep = (onPreviewShell ? pathname : "/runner/") + (window.location.search || "");
       window.history.pushState({}, "", keep);
       window.dispatchEvent(new HashChangeEvent("hashchange"));
     }
@@ -838,16 +862,11 @@
       }
     }
 
-    // 6) BrowserRouter fallback — stay under /runner/ when hosted there.
+    // 6) BrowserRouter fallback — stay under the preview shell (/runner/ or /projects/.../draft).
     try {
-      if (!onRunner) return;
-      var runnerBase = pathname.match(/^(\/runner\/?)/i);
-      var base = runnerBase
-        ? runnerBase[1].endsWith("/")
-          ? runnerBase[1]
-          : runnerBase[1] + "/"
-        : "/runner/";
-      var nextPath = pageKey ? base + pageKey : base;
+      if (!onPreviewShell) return;
+      var prefix = shellBasePrefix();
+      var nextPath = pageKey ? prefix + "/" + pageKey : prefix + "/";
       var currentPath = pathname.replace(/\/+$/, "") || "/";
       var wantPath = nextPath.replace(/\/+$/, "") || "/";
       if (currentPath !== wantPath) {
@@ -862,6 +881,27 @@
 
   ensureStyle();
   notifyReady();
+
+  // Block plain anchors from escaping the preview shell to the API root (/).
+  document.addEventListener(
+    "click",
+    function (ev) {
+      var prefix = shellBasePrefix();
+      if (!prefix) return;
+      var link = ev.target && ev.target.closest ? ev.target.closest("a[href]") : null;
+      if (!link) return;
+      var href = (link.getAttribute("href") || "").trim();
+      if (!href || href.startsWith("#") || href.startsWith("mailto:") || /^https?:/i.test(href)) return;
+      if (!href.startsWith("/")) return;
+      var normalizedHref = href.replace(/\/+$/, "") || "/";
+      var normalizedPrefix = prefix.replace(/\/+$/, "") || "/";
+      if (normalizedHref === normalizedPrefix || normalizedHref.indexOf(normalizedPrefix + "/") === 0) return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      navigatePreviewPath(normalizedHref === "/" ? "/" : normalizedHref);
+    },
+    true,
+  );
 
   var previewSyncTimer = null;
   function schedulePreviewSync() {

--- a/apps/api/runtime/public/runner.js
+++ b/apps/api/runtime/public/runner.js
@@ -71,7 +71,26 @@ window.addEventListener("unhandledrejection", (e) => {
 // project-public endpoint; every root-path <img> is rewritten to it, with the
 // original kept in data-forge-src so the visual-image bridge still reports
 // the literal that actually lives in the source.
-let ASSETS = null; // { base: string, token?: string }
+let ASSETS = null; // { base: string, token?: string, routerBase?: string }
+
+/** Preview shell prefix: /runner or /projects/{uuid}/draft — never bare API /. */
+function getPreviewShellBase() {
+  if (typeof window.__FORGE_PREVIEW_SHELL_BASE__ === "string" && window.__FORGE_PREVIEW_SHELL_BASE__) {
+    return window.__FORGE_PREVIEW_SHELL_BASE__;
+  }
+  const p = window.location.pathname || "";
+  const draft = p.match(/^(\/projects\/[0-9a-f-]{36}\/draft)\/?/i);
+  if (draft) return draft[1];
+  if (/^\/runner\/?/i.test(p)) return "/runner";
+  return "";
+}
+
+function injectRouterBasename(code) {
+  const base = getPreviewShellBase();
+  if (!base || !code.includes("BrowserRouter")) return code;
+  if (/\bbasename\s*[=:]/.test(code)) return code;
+  return code.replace(/<BrowserRouter(?![^>]*\bbasename\b)(\s|>)/g, `<BrowserRouter basename="${base}"$1`);
+}
 
 function resolveAssetUrl(src, assets) {
   if (!assets || !assets.base || typeof src !== "string") return null;
@@ -193,7 +212,8 @@ function transform(code, path) {
       babelrc: false,
     });
     const js = out.code || "";
-    return { code: js, imports: collectImports(js), error: null };
+    const patched = injectRouterBasename(js);
+    return { code: patched, imports: collectImports(patched), error: null };
   } catch (e) {
     return {
       code: "",
@@ -344,6 +364,9 @@ async function waitForFirstPaint(timeoutMs = 8000) {
 
 async function mount(files, entry, tokensCss, assets) {
   if (assets && typeof assets.base === "string" && assets.base) ASSETS = assets;
+  if (assets && typeof assets.routerBase === "string" && assets.routerBase) {
+    window.__FORGE_PREVIEW_SHELL_BASE__ = assets.routerBase;
+  }
   const cssEl = document.getElementById("forge-app-css");
   if (cssEl) {
     // Every stylesheet ships, index.css (tokens/layout) first: per-page CSS
@@ -502,6 +525,9 @@ window.addEventListener("message", (e) => {
 // shell (GET /projects/{id}/draft), so the page renders without a builder
 // parent to postMessage it. In that mode there is no peer to notify.
 const DRAFT = window.__FORGE_DRAFT__;
+if (DRAFT && DRAFT.assets && typeof DRAFT.assets.routerBase === "string") {
+  window.__FORGE_PREVIEW_SHELL_BASE__ = DRAFT.assets.routerBase;
+}
 if (DRAFT && DRAFT.files) {
   void mount(DRAFT.files, DRAFT.entry || "src/main.tsx", DRAFT.tokens || "", DRAFT.assets || null);
 } else {

--- a/apps/web/components/builder/PreviewPane.tsx
+++ b/apps/web/components/builder/PreviewPane.tsx
@@ -146,6 +146,7 @@ export function PreviewPane({
             assets: {
               base: `${apiBase().replace(/\/$/, "")}/projects/${projectId}/public`,
               token: getToken() ?? "",
+              routerBase: "/runner",
             },
           },
           target,


### PR DESCRIPTION
## Summary
- Injecte `basename` sur BrowserRouter en preview (/runner et /projects/{id}/draft)
- Bloque les liens qui sortiraient vers la racine API (api-forge.rodiumai.io/)
- Corrige la home qui ne s affichait pas au chargement du draft

## Test plan
- [ ] Ouvrir /projects/{id}/draft → page accueil visible
- [ ] Cliquer Accueil → reste sous /projects/{id}/draft
- [ ] Preview intégrée builder → navigation OK sous /runner/