### PR TITLE
fix(preview): basename react-router pour miniatures dashboard

### DIFF
--- a/apps/api/app/routers/preview.py
+++ b/apps/api/app/routers/preview.py
@@ -29,6 +29,8 @@ router = APIRouter(tags=["preview"])
 _DRAFT_THUMB_CACHE: dict[str, tuple[float, str]] = {}
 _DRAFT_THUMB_TTL_S = 90.0
 _DRAFT_THUMB_CACHE_MAX = 40
+# Bump when runner shell / basename injection changes — avoids stale thumb HTML.
+_DRAFT_THUMB_CACHE_VERSION = 2
 
 
 class SourceBundle(BaseModel):
@@ -57,12 +59,16 @@ def _project_extra_imports(project_id: str) -> dict[str, str]:
         return {}
 
 
+def _draft_thumb_cache_key(project_id: str) -> str:
+    return f"{project_id}:v{_DRAFT_THUMB_CACHE_VERSION}"
+
+
 def _draft_thumb_cache_get(project_id: str) -> str | None:
-    row = _DRAFT_THUMB_CACHE.get(project_id)
+    row = _DRAFT_THUMB_CACHE.get(_draft_thumb_cache_key(project_id))
     if not row:
         return None
     if time.time() - row[0] > _DRAFT_THUMB_TTL_S:
-        _DRAFT_THUMB_CACHE.pop(project_id, None)
+        _DRAFT_THUMB_CACHE.pop(_draft_thumb_cache_key(project_id), None)
         return None
     return row[1]
 
@@ -70,7 +76,7 @@ def _draft_thumb_cache_get(project_id: str) -> str | None:
 def _draft_thumb_cache_set(project_id: str, html: str) -> None:
     if len(_DRAFT_THUMB_CACHE) >= _DRAFT_THUMB_CACHE_MAX:
         _DRAFT_THUMB_CACHE.pop(next(iter(_DRAFT_THUMB_CACHE)), None)
-    _DRAFT_THUMB_CACHE[project_id] = (time.time(), html)
+    _DRAFT_THUMB_CACHE[_draft_thumb_cache_key(project_id)] = (time.time(), html)
 
 
 def _status(project: Project, *, running: bool) -> PreviewStatus:

--- a/apps/api/app/routers/preview.py
+++ b/apps/api/app/routers/preview.py
@@ -159,7 +159,9 @@ def draft_page(
     )
     if is_thumb:
         _draft_thumb_cache_set(pid, html)
-    return HTMLResponse(html, headers={"Cache-Control": "no-store" if not is_thumb else "private, max-age=60"})
+    return HTMLResponse(
+        html, headers={"Cache-Control": "no-store" if not is_thumb else "private, max-age=60"}
+    )
 
 
 @router.post("/projects/{project_id}/preview/start", response_model=PreviewStatus)

--- a/apps/api/app/services/preview_babel.py
+++ b/apps/api/app/services/preview_babel.py
@@ -86,12 +86,13 @@ def render_runner_shell(
   <style id="forge-tokens"></style>
   <style id="forge-app-css"></style>
   <script>window.__FORGE_PARENT_ORIGINS = {origins};</script>
+  <script>(function(){{var m=location.pathname.match(/^(\\/projects\\/[0-9a-f-]{{36}}\\/draft)/i);if(m)window.__FORGE_PREVIEW_SHELL_BASE__=m[1];}})();</script>
   {thumb_css}{draft}<script src="https://unpkg.com/@babel/standalone@7.26.9/babel.min.js"></script>
 </head>
 <body>
   <div id="root"></div>
-  <script src="/runner/bridge.js?v=nav6"></script>
-  <script type="module" src="/runner/runner.js?v=nav6"></script>
+  <script src="/runner/bridge.js?v=nav7"></script>
+  <script type="module" src="/runner/runner.js?v=nav7"></script>
 </body>
 </html>
 """

--- a/apps/api/runtime/public/runner.js
+++ b/apps/api/runtime/public/runner.js
@@ -85,11 +85,80 @@ function getPreviewShellBase() {
   return "";
 }
 
-function injectRouterBasename(code) {
-  const base = getPreviewShellBase();
-  if (!base || !code.includes("BrowserRouter")) return code;
-  if (/\bbasename\s*[=:]/.test(code)) return code;
-  return code.replace(/<BrowserRouter(?![^>]*\bbasename\b)(\s|>)/g, `<BrowserRouter basename="${base}"$1`);
+function jsxHasBasenameAttr(attributes) {
+  return attributes.some(
+    (a) =>
+      a.type === "JSXAttribute" &&
+      a.name &&
+      a.name.type === "JSXIdentifier" &&
+      a.name.name === "basename",
+  );
+}
+
+function objectHasBasenameProperty(properties) {
+  return properties.some((p) => {
+    if (p.type !== "ObjectProperty") return false;
+    const key = p.key;
+    return (
+      (key.type === "Identifier" && key.name === "basename") ||
+      (key.type === "StringLiteral" && key.value === "basename")
+    );
+  });
+}
+
+/** Inject react-router basename so /projects/{id}/draft maps to app routes (/). */
+function basenamePreviewPlugin(_api, opts) {
+  const t = _api.types;
+  const base = opts.basename;
+  if (!base) return { visitor: {} };
+
+  function addBasenameAttr(path) {
+    if (jsxHasBasenameAttr(path.node.attributes)) return;
+    path.node.attributes.unshift(
+      t.jsxAttribute(t.jsxIdentifier("basename"), t.stringLiteral(base)),
+    );
+  }
+
+  function ensureBasenameOptions(args) {
+    let opts = args[1];
+    if (!opts) {
+      opts = t.objectExpression([]);
+      args.push(opts);
+    }
+    if (!t.isObjectExpression(opts) || objectHasBasenameProperty(opts.properties)) return;
+    opts.properties.unshift(
+      t.objectProperty(t.identifier("basename"), t.stringLiteral(base)),
+    );
+  }
+
+  return {
+    visitor: {
+      JSXOpeningElement(path) {
+        const name = path.node.name;
+        if (t.isJSXIdentifier(name) && name.name === "BrowserRouter") {
+          addBasenameAttr(path);
+          return;
+        }
+        if (
+          t.isJSXMemberExpression(name) &&
+          t.isJSXIdentifier(name.property) &&
+          name.property.name === "BrowserRouter"
+        ) {
+          addBasenameAttr(path);
+        }
+      },
+      CallExpression(path) {
+        const callee = path.node.callee;
+        if (!t.isIdentifier(callee) || callee.name !== "createBrowserRouter") return;
+        if (!path.node.arguments.length) return;
+        ensureBasenameOptions(path.node.arguments);
+      },
+    },
+  };
+}
+
+function needsRouterBasename(code) {
+  return code.includes("BrowserRouter") || code.includes("createBrowserRouter");
 }
 
 function resolveAssetUrl(src, assets) {
@@ -203,17 +272,22 @@ function collectImports(code) {
 
 function transform(code, path) {
   try {
+    const base = getPreviewShellBase();
+    const plugins = [];
+    if (base && needsRouterBasename(code)) {
+      plugins.push([basenamePreviewPlugin, { basename: base }]);
+    }
     const out = Babel.transform(code, {
       filename: path,
       presets: PRESETS,
+      plugins,
       sourceMaps: "inline",
       compact: false,
       configFile: false,
       babelrc: false,
     });
     const js = out.code || "";
-    const patched = injectRouterBasename(js);
-    return { code: patched, imports: collectImports(patched), error: null };
+    return { code: js, imports: collectImports(js), error: null };
   } catch (e) {
     return {
       code: "",

--- a/apps/api/tests/test_attachment_asset_materialize.py
+++ b/apps/api/tests/test_attachment_asset_materialize.py
@@ -32,9 +32,7 @@ def materialize_setup(project, monkeypatch):
 def test_materialize_asset_markers_rewrites_private_s3_url(materialize_setup):
     project, object_id = materialize_setup
     s3 = "https://rodiumai-forge-uploads-prod.s3.eu-west-1.amazonaws.com/forge/u/p/x-logo.png"
-    text = (
-        f"[Image attached: logo.png | url:{s3} | object:{object_id} | intent:asset]"
-    )
+    text = f"[Image attached: logo.png | url:{s3} | object:{object_id} | intent:asset]"
     out = materialize_asset_markers(object(), project, text)
     assert s3 not in out
     assert "/images/" in out


### PR DESCRIPTION
## Summary
- Injection Babel du basename pour BrowserRouter et createBrowserRouter
- Script bootstrap __FORGE_PREVIEW_SHELL_BASE__ dans le shell draft
- Cache thumb v2 + runner nav7

## Test plan
- [ ] Dashboard : plus d erreur No routes matched sur les miniatures
- [ ] Preview builder : navigation interne OK
- [ ] Upload image + affichage public OK

Made with [Cursor](https://cursor.com)