### PR TITLE
fix(preview): refresh doux, reconnexion SSE, fin du clignotement pendant les runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,16 @@ task-definition-deploy.json
 /scripts/
 
 
+
+# Secrets & credentials � never commit
+*.pem
+*.key
+*.p12
+*.pfx
+.env.*
+!.env.example
+!*.env.example
+!.env.ecs.example
+*.tfstate
+*.tfstate.backup
+!.env.production.example

--- a/apps/api/app/services/orchestration/dispatcher.py
+++ b/apps/api/app/services/orchestration/dispatcher.py
@@ -432,6 +432,11 @@ async def run_plan_tasks(
         await emit_progress(idx)
         yield push_step(f"task:{tid}", title, "done")
         yield _sse({"type": "plan_task", "id": tid, "status": "done", "label": title})
+        # One preview refresh per completed task (not per file write): the
+        # client used to reload the iframe on every write, which flickered
+        # non-stop during multi-task plans.
+        if written:
+            yield _sse({"type": "preview_refresh"})
 
         # Mid-plan CSS/build check — catch orphan classes before the next rewrite.
         if len(tasks) >= 2 and tid != "coherence":

--- a/apps/api/scripts/admin_delete_project.py
+++ b/apps/api/scripts/admin_delete_project.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Delete a Forge project via the internal admin API.
+
+Usage (prod):
+  set ADMIN_SECRET=...
+  set FORGE_API_BASE=https://api-forge.rodiumai.io
+  python scripts/admin_delete_project.py <project-uuid>
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.error
+import urllib.request
+from uuid import UUID
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: admin_delete_project.py <project-uuid>", file=sys.stderr)
+        return 2
+
+    try:
+        project_id = str(UUID(sys.argv[1]))
+    except ValueError:
+        print("Invalid project UUID.", file=sys.stderr)
+        return 2
+
+    secret = (os.environ.get("ADMIN_SECRET") or "").strip()
+    if not secret:
+        print("ADMIN_SECRET is required.", file=sys.stderr)
+        return 2
+
+    base = (os.environ.get("FORGE_API_BASE") or "http://127.0.0.1:8100").rstrip("/")
+    url = f"{base}/internal/admin/projects/{project_id}"
+    req = urllib.request.Request(
+        url,
+        method="DELETE",
+        headers={"X-Forge-Admin-Secret": secret},
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            print(f"Deleted project {project_id} (HTTP {resp.status}).")
+            return 0
+    except urllib.error.HTTPError as err:
+        body = err.read().decode("utf-8", errors="replace")
+        print(f"HTTP {err.code}: {body}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/web/app/projects/[id]/page.tsx
+++ b/apps/web/app/projects/[id]/page.tsx
@@ -253,6 +253,16 @@ function formatStreamError(err: unknown, labels: ReturnType<typeof streamErrorLa
   });
 }
 
+/** Network-level stream failure (drop, reset, proxy timeout) — worth an
+ *  automatic reconnect to the run's buffered event stream instead of an
+ *  error bubble that resets the whole plan UI. */
+function isNetworkStreamError(err: unknown): boolean {
+  const raw = err instanceof Error ? err.message : String(err || "");
+  return /failed to fetch|networkerror|network request failed|load failed|timed out|timeout|incomplete chunked|peer closed connection|connection reset|err_network|aborted/i.test(
+    raw,
+  );
+}
+
 /** Human label for the selection chip — never the raw CSS selector path.
  *  Prefers #id, then tag + a short text excerpt (e.g. `nav · “PromptVault”`). */
 function selectionChipLabel(sel: ElementSelection): string {
@@ -701,7 +711,7 @@ export default function ProjectPage() {
           sawRemoteRun = false;
           setFilesRevision((rev) => rev + 1);
           void refreshRoutes();
-          void forcePreviewRefresh({ softStart: true, remount: true });
+          void forcePreviewRefresh({ softStart: true, remount: true, quiet: true });
         }
       } catch {
         /* transient — next tick retries */
@@ -942,7 +952,7 @@ export default function ProjectPage() {
             schedulePreviewRefresh();
             break;
           case "ensure-preview-started":
-            if (!previewUrl && !previewBusy) void startPreview();
+            if (!previewUrl && !previewBusy) void startPreview({ quiet: true });
             break;
           case "cancelled":
             break;
@@ -989,7 +999,7 @@ export default function ProjectPage() {
             });
             setStreamSummary("");
             if (applied) {
-              void forcePreviewRefresh({ restart: true });
+              void forcePreviewRefresh({ restart: true, quiet: true });
               setMainMode("preview");
               setMobilePane("workspace");
               setPreviewTool(null);
@@ -1030,59 +1040,85 @@ export default function ProjectPage() {
       streamingRunIdRef.current = runId;
       setBusy(true);
       setError(null);
+      // Reconnect support: the backend buffers run events and replays them
+      // from `?after=N`. On a network drop we resume from the cursor instead
+      // of surfacing an error and resetting the plan UI.
+      let seen = 0;
+      let attempts = 0;
+      let sawTerminal = false;
+      let detached = false;
       try {
-        const res = await fetch(
-          `${apiBase()}/projects/${projectId}/chats/${chatId}/runs/${runId}/events`,
-          {
-            method: "GET",
-            signal: abortCtrl.signal,
-            headers: {
-              Authorization: `Bearer ${getToken()}`,
-              "Accept-Language": locale,
-              Accept: "text/event-stream",
-            },
-          },
-        );
-        if (!res.ok || !res.body) {
-          throw new Error(res.statusText || t("streamError"));
-        }
         const stateRef = seedStreamState();
         setStreamActive(true);
-        await readSseStream(res, async (payloadEvent) => {
-          if (
-            String(payloadEvent.type || "") === "error" &&
-            String(payloadEvent.message || "") === "run_detached"
-          ) {
-            try {
-              const active = await api<{
-                id: string;
-                status: string;
-                plan: PlanTask[];
-              } | null>(`/projects/${projectId}/chats/${chatId}/runs/active`);
-              if (!active?.id || !Array.isArray(active.plan) || !active.plan.length) {
-                setPlanTasks([]);
-                setPlanNeedsConfirm(false);
-                setBusy(false);
+        while (!sawTerminal && !detached) {
+          try {
+            const res = await fetch(
+              `${apiBase()}/projects/${projectId}/chats/${chatId}/runs/${runId}/events?after=${seen}`,
+              {
+                method: "GET",
+                signal: abortCtrl.signal,
+                headers: {
+                  Authorization: `Bearer ${getToken()}`,
+                  "Accept-Language": locale,
+                  Accept: "text/event-stream",
+                },
+              },
+            );
+            if (!res.ok || !res.body) {
+              throw new Error(res.statusText || t("streamError"));
+            }
+            await readSseStream(res, async (payloadEvent) => {
+              const type = String(payloadEvent.type || "");
+              if (type === "error" && String(payloadEvent.message || "") === "run_detached") {
+                // Synthetic marker from the server poll loop — not a buffered
+                // run event, so it must NOT advance the cursor.
+                detached = true;
+                try {
+                  const active = await api<{
+                    id: string;
+                    status: string;
+                    plan: PlanTask[];
+                  } | null>(`/projects/${projectId}/chats/${chatId}/runs/active`);
+                  if (!active?.id || !Array.isArray(active.plan) || !active.plan.length) {
+                    setPlanTasks([]);
+                    setPlanNeedsConfirm(false);
+                    setBusy(false);
+                    return;
+                  }
+                  const mapped = mapActivePlanTasks(active.plan);
+                  const doneCount = mapped.filter((task) => task.status === "done").length;
+                  const partialProgress = doneCount > 0 && doneCount < mapped.length;
+                  setPlanTasks(mapped);
+                  setPlanNeedsConfirm(active.status === "awaiting_plan_confirm" && !partialProgress);
+                  setBusy(active.status === "running");
+                } catch {
+                  setPlanNeedsConfirm(true);
+                  setBusy(false);
+                }
                 return;
               }
-              const mapped = mapActivePlanTasks(active.plan);
-              const doneCount = mapped.filter((task) => task.status === "done").length;
-              const partialProgress = doneCount > 0 && doneCount < mapped.length;
-              setPlanTasks(mapped);
-              setPlanNeedsConfirm(active.status === "awaiting_plan_confirm" && !partialProgress);
-              setBusy(active.status === "running");
-            } catch {
-              setPlanNeedsConfirm(true);
-              setBusy(false);
+              seen += 1;
+              attempts = 0;
+              if (type === "done" || type === "error") sawTerminal = true;
+              handleStreamEvent(payloadEvent, {
+                stateRef,
+                userPayload: "",
+                clearBootOnce: () => undefined,
+              });
+            });
+            // Stream closed cleanly without a terminal event (proxy idle
+            // cut...): reconnect from the cursor like a network error.
+            if (!sawTerminal && !detached) throw new Error("stream ended early");
+          } catch (err) {
+            if (abortCtrl.signal.aborted || (err instanceof Error && err.name === "AbortError")) {
+              return;
             }
-            return;
+            attempts += 1;
+            if (attempts > 5) throw err;
+            await new Promise((resolve) => setTimeout(resolve, Math.min(8_000, 500 * 2 ** attempts)));
+            if (abortCtrl.signal.aborted) return;
           }
-          handleStreamEvent(payloadEvent, {
-            stateRef,
-            userPayload: "",
-            clearBootOnce: () => undefined,
-          });
-        });
+        }
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") return;
         pushChatError(formatStreamError(err, streamErrLabels), {
@@ -1410,6 +1446,13 @@ export default function ProjectPage() {
         if (err instanceof Error && err.name === "AbortError") {
           return;
         }
+        // Network drop mid-run: the backend keeps executing and buffers every
+        // event — reattach to the run stream instead of erroring + resetting.
+        const dropRunId = streamingRunIdRef.current;
+        if (dropRunId && isNetworkStreamError(err)) {
+          await subscribeRunEvents(dropRunId);
+          return;
+        }
         if (opts.bootKey) {
           setBootRetryPrompt(payload);
         }
@@ -1439,7 +1482,7 @@ export default function ProjectPage() {
         void refreshRodiumWallet();
       }
     },
-    [busy, chatId, editingMessageId, elementSelection, handleStreamEvent, locale, planMode, projectId, pushChatError, seedStreamState, streamErrLabels, t],
+    [busy, chatId, editingMessageId, elementSelection, handleStreamEvent, locale, planMode, projectId, pushChatError, seedStreamState, streamErrLabels, subscribeRunEvents, t],
   );
 
   const submitClarify = useCallback(
@@ -1553,6 +1596,13 @@ export default function ProjectPage() {
       if (err instanceof Error && err.name === "AbortError") {
         return;
       }
+      // Network drop mid-plan: the run keeps going server-side — reattach to
+      // the buffered event stream instead of flipping tasks back to pending.
+      const dropRunId = streamingRunIdRef.current || activeRunId;
+      if (dropRunId && isNetworkStreamError(err)) {
+        await subscribeRunEvents(dropRunId);
+        return;
+      }
       pushChatError(formatStreamError(err, streamErrLabels), {
         kind: "plan",
       });
@@ -1574,7 +1624,7 @@ export default function ProjectPage() {
       setBusy(false);
       void refreshRodiumWallet();
     }
-  }, [activeRunId, chatId, handleStreamEvent, locale, planTasks, projectId, pushChatError, seedStreamState, streamErrLabels, t]);
+  }, [activeRunId, chatId, handleStreamEvent, locale, planTasks, projectId, pushChatError, seedStreamState, streamErrLabels, subscribeRunEvents, t]);
 
   useEffect(() => {
     if (!chatId || loading || bootSentRef.current || bootInFlight.has(projectId)) return;
@@ -1732,7 +1782,7 @@ export default function ProjectPage() {
           if (mode !== "preview") setPreviewTool(null);
           syncBuilderUrl({ mainMode: mode, mobilePane: "workspace", previewTool: nextTool });
           if (mode === "preview") {
-            void forcePreviewRefresh({ softStart: true, remount: false });
+            void forcePreviewRefresh({ softStart: true, remount: false, quiet: true });
           }
         }}
         viewport={viewport}

--- a/apps/web/components/builder/PreviewPane.tsx
+++ b/apps/web/components/builder/PreviewPane.tsx
@@ -120,6 +120,9 @@ export function PreviewPane({
   desiredToolRef.current = previewTool;
 
   const runnerReadyRef = useRef(false);
+  // True once the app mounted in the iframe: later runtime errors must not
+  // slam the blocking "Restart preview" overlay over a site that still works.
+  const appMountedRef = useRef(false);
   const [babelError, setBabelError] = useState<string | null>(null);
 
   // Babel runner: push source bundle into the iframe (origin = API).
@@ -170,16 +173,30 @@ export function PreviewPane({
         // App mounted — that says nothing about the visual-edit bridge, which
         // acknowledges separately via forge-tool-ack. Conflating the two showed
         // "click to edit" next to "bridge unavailable" at the same time.
+        appMountedRef.current = true;
         setLoadError(false);
         setBabelError(null);
       }
       if (data.type === "forge:transform-error" || data.type === "forge:error") {
-        setLoadError(true);
         const err = data.error && typeof data.error === "object" ? data.error : data;
+        const msg = typeof err.message === "string" ? err.message : "Preview error";
+        // Known-benign DOM noise (bridge/contentEditable vs React reconciliation,
+        // stale selectors): never block the preview for these.
+        const benign =
+          /removeChild|insertBefore|not a child of this node|is not a valid selector|ResizeObserver loop/i.test(
+            msg,
+          );
+        // Runtime error AFTER a successful mount: the site is still rendered —
+        // opening the same app in a new tab shows no blocking overlay either.
+        const afterMount = data.type === "forge:error" && appMountedRef.current;
+        if (benign || afterMount) {
+          console.debug("[forge] preview runtime error (non-blocking):", msg);
+          return;
+        }
+        setLoadError(true);
         const path = typeof err.path === "string" ? err.path : "";
         const line = err.line != null ? `:${err.line}` : "";
         const col = err.column != null ? `:${err.column}` : "";
-        const msg = typeof err.message === "string" ? err.message : "Preview error";
         const loc = path ? `${path}${line}${col}` : "";
         setBabelError(loc ? `${loc} — ${msg}` : msg);
       }
@@ -198,6 +215,7 @@ export function PreviewPane({
 
   useEffect(() => {
     setLoadError(false);
+    appMountedRef.current = false;
   }, [previewSrc]);
 
   function clearNavigateRetries() {

--- a/apps/web/components/builder/usePreviewControl.ts
+++ b/apps/web/components/builder/usePreviewControl.ts
@@ -19,6 +19,8 @@ export type RefreshOptions = {
   remount?: boolean;
   /** Ask the server for a clean restart. */
   restart?: boolean;
+  /** Background-triggered refresh: never surface errors in the chat. */
+  quiet?: boolean;
 };
 
 type Params = {
@@ -49,6 +51,21 @@ export function usePreviewControl({ projectId, loading, onError, previewFailedLa
   const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const updatingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoStarted = useRef(false);
+  // Ref mirror so the debounced refresh reads the CURRENT url, not a stale closure.
+  const previewUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    previewUrlRef.current = previewUrl;
+  }, [previewUrl]);
+
+  /** Short "updating" flash after an optimistic in-place edit. */
+  const flashUpdating = useCallback((ms = 1200) => {
+    setPreviewUpdating(true);
+    if (updatingTimer.current) clearTimeout(updatingTimer.current);
+    updatingTimer.current = setTimeout(() => {
+      setPreviewUpdating(false);
+      updatingTimer.current = null;
+    }, ms);
+  }, []);
 
   const previewSrc = useMemo(
     () => buildPreviewSrc(previewUrl, previewKey, apiBase()),
@@ -57,20 +74,27 @@ export function usePreviewControl({ projectId, loading, onError, previewFailedLa
 
   const remount = useCallback(() => setPreviewKey((k) => k + 1), []);
 
-  const startPreview = useCallback(async () => {
-    setPreviewBusy(true);
-    try {
-      const status = await api<PreviewStatusResponse>(`/projects/${projectId}/preview/start`, {
-        method: "POST",
-      });
-      setPreviewUrl(status.runner_url || status.url);
-      remount();
-    } catch (err) {
-      onError(err instanceof Error ? err.message : previewFailedLabel);
-    } finally {
-      setPreviewBusy(false);
-    }
-  }, [onError, previewFailedLabel, projectId, remount]);
+  const startPreview = useCallback(
+    async (opts?: { quiet?: boolean }) => {
+      setPreviewBusy(true);
+      try {
+        const status = await api<PreviewStatusResponse>(`/projects/${projectId}/preview/start`, {
+          method: "POST",
+          timeoutMs: 45_000,
+        });
+        setPreviewUrl(status.runner_url || status.url);
+        remount();
+      } catch (err) {
+        // Background auto-starts (fired on agent file writes) must not spam
+        // the chat with "Request timed out after 90000ms" while the backend
+        // is busy generating.
+        if (!opts?.quiet) onError(err instanceof Error ? err.message : previewFailedLabel);
+      } finally {
+        setPreviewBusy(false);
+      }
+    },
+    [onError, previewFailedLabel, projectId, remount],
+  );
 
   const forcePreviewRefresh = useCallback(
     async (opts?: RefreshOptions) => {
@@ -86,27 +110,27 @@ export function usePreviewControl({ projectId, loading, onError, previewFailedLa
         try {
           const status = await api<PreviewStatusResponse>(
             `/projects/${projectId}/preview/restart`,
-            { method: "POST" },
+            { method: "POST", timeoutMs: 45_000 },
           );
           if (status.url) setPreviewUrl(status.runner_url || status.url);
           if (shouldRemount) remount();
         } catch (err) {
           // Fall back to a plain start if restart is unavailable.
-          await startPreview();
+          await startPreview({ quiet: opts?.quiet });
           if (shouldRemount) remount();
-          onError(err instanceof Error ? err.message : previewFailedLabel);
+          if (!opts?.quiet) onError(err instanceof Error ? err.message : previewFailedLabel);
         }
       } else if (opts?.softStart) {
         try {
           const status = await api<PreviewStatusResponse>(`/projects/${projectId}/preview`);
           if (!status.running || !status.url) {
-            await startPreview();
+            await startPreview({ quiet: opts?.quiet });
           } else {
             setPreviewUrl(status.runner_url || status.url);
             if (shouldRemount) remount();
           }
         } catch {
-          await startPreview();
+          await startPreview({ quiet: opts?.quiet });
         }
       } else if (shouldRemount) {
         remount();
@@ -120,24 +144,22 @@ export function usePreviewControl({ projectId, loading, onError, previewFailedLa
     [onError, previewFailedLabel, projectId, remount, startPreview],
   );
 
-  /** Debounced restart, so a burst of agent writes triggers a single reload. */
+  /** Debounced SOFT refresh during agent runs: re-push the source bundle into
+   *  the already-loaded runner (no server restart, no iframe reload — the old
+   *  restart-per-burst made the screen flicker for the whole run). Falls back
+   *  to a quiet start when the preview is not up yet. */
   const schedulePreviewRefresh = useCallback(() => {
     if (refreshTimer.current) clearTimeout(refreshTimer.current);
     refreshTimer.current = setTimeout(() => {
       refreshTimer.current = null;
-      void forcePreviewRefresh({ restart: true });
-    }, 900);
-  }, [forcePreviewRefresh]);
-
-  /** Short "updating" flash after an optimistic in-place edit. */
-  const flashUpdating = useCallback((ms = 1200) => {
-    setPreviewUpdating(true);
-    if (updatingTimer.current) clearTimeout(updatingTimer.current);
-    updatingTimer.current = setTimeout(() => {
-      setPreviewUpdating(false);
-      updatingTimer.current = null;
-    }, ms);
-  }, []);
+      if (previewUrlRef.current) {
+        setRenderNonce((n) => n + 1);
+        flashUpdating();
+      } else {
+        void forcePreviewRefresh({ softStart: true, quiet: true });
+      }
+    }, 1200);
+  }, [flashUpdating, forcePreviewRefresh]);
 
   /** Soft sync after a visual edit: re-push the bundle, keep the iframe alive. */
   const repushPreview = useCallback(() => {

--- a/apps/web/lib/chat-stream.test.ts
+++ b/apps/web/lib/chat-stream.test.ts
@@ -146,16 +146,19 @@ describe("file operations", () => {
     expect(state.ops[0].taskId).toBeUndefined();
   });
 
-  it("asks to refresh routes and start the preview only on writes", () => {
+  it("asks to refresh routes and start the preview only on writes — never a preview refresh per file", () => {
     const write = reduceStreamEvent(initialStreamState(), { type: "file_write", path: "a" }, OPTS);
     expect(kinds(write.effects)).toEqual([
-      "schedule-preview-refresh",
       "refresh-routes",
       "ensure-preview-started",
     ]);
 
     const del = reduceStreamEvent(initialStreamState(), { type: "file_delete", path: "a" }, OPTS);
-    expect(kinds(del.effects)).toEqual(["schedule-preview-refresh"]);
+    expect(kinds(del.effects)).toEqual([]);
+
+    // Preview refreshes are driven by explicit dispatcher events only.
+    const refresh = reduceStreamEvent(initialStreamState(), { type: "preview_refresh" }, OPTS);
+    expect(kinds(refresh.effects)).toEqual(["schedule-preview-refresh"]);
   });
 });
 

--- a/apps/web/lib/chat-stream.ts
+++ b/apps/web/lib/chat-stream.ts
@@ -207,7 +207,9 @@ export function reduceStreamEvent(
       taskId: next.currentTaskId || undefined,
     };
     next = { ...next, ops: [...next.ops, op], applied: true };
-    effects.push({ kind: "schedule-preview-refresh" });
+    // No preview refresh here: one refresh per WRITE caused an endless
+    // restart→remount→reload loop for the whole run. The dispatcher emits
+    // explicit `preview_refresh` events at task boundaries instead.
     if (type === "file_write") {
       effects.push({ kind: "refresh-routes" }, { kind: "ensure-preview-started" });
     }


### PR DESCRIPTION
## Problemes corriges

1. **Clignotement de l'ecran pendant l'execution d'un plan** : chaque file_write declenchait un restart serveur + remount iframe (debounce 900ms). Desormais le dispatcher emet un preview_refresh par tache terminee, et le refresh re-pousse le bundle dans l'iframe deja chargee (zero reload).
2. **'Request timed out after 90000ms' dans le chat** : venait des POST /preview/restart|start declenches en rafale pendant la generation. Appels arriere-plan passes en quiet + timeout 45s.
3. **Aucune reconnexion SSE** : subscribeRunEvents reconnecte automatiquement avec curseur ?after=N (5 tentatives, backoff expo) ; sendMessage/executePlan se rattachent au stream bufferise du run sur coupure reseau au lieu d'afficher une erreur et de reinitialiser le plan.
4. **Overlay 'Restart preview' trop agressif** : n'apparait plus pour les erreurs runtime apres mount ni pour les erreurs DOM benignes (removeChild/insertBefore/selector invalide) — comportement identique au site ouvert en nouvel onglet.

## Divers
- Durcissement .gitignore (pem/key/env.*/tfstate) avant passage en public
- Script ops admin_delete_project.py

## Tests
- Backend: 219 pytest OK
- Frontend: 158 vitest OK, tsc --noEmit OK