### PR TITLE
fix(runs): rattachement auto au run en cours, fin du clignotement Resume

### DIFF
--- a/apps/web/app/projects/[id]/page.tsx
+++ b/apps/web/app/projects/[id]/page.tsx
@@ -356,6 +356,10 @@ export default function ProjectPage() {
   /** Runs the user explicitly stopped — ignore Firestore "running" echoes for these. */
   const ignoredRunIdsRef = useRef<Set<string>>(new Set());
   const streamingRunIdRef = useRef<string | null>(null);
+  /** Late-bound handle: the poll effect is declared before subscribeRunEvents. */
+  const subscribeRunEventsRef = useRef<((runId: string) => Promise<void>) | null>(null);
+  /** Run ids whose auto-reattach failed recently — cool-down before retrying. */
+  const failedSubscribesRef = useRef<Map<string, number>>(new Map());
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const bootSentRef = useRef(false);
@@ -706,6 +710,19 @@ export default function ProjectPage() {
         if (active?.id && !ignoredRunIdsRef.current.has(active.id)) {
           sawRemoteRun = true;
           setActiveRunId(active.id);
+          // A run is EXECUTING but no local stream is attached (dropped SSE,
+          // other tab): reattach immediately. Without this the composer stayed
+          // editable and the panel showed "Resume plan" while the plan ran —
+          // and clicking Resume hit a 400 (run_invalid_state) that wiped the
+          // plan, flickering the whole panel.
+          const failedAt = failedSubscribesRef.current.get(active.id) || 0;
+          if (
+            active.status === "running" &&
+            !streamAbortRef.current &&
+            Date.now() - failedAt > 60_000
+          ) {
+            void subscribeRunEventsRef.current?.(active.id);
+          }
         } else if (sawRemoteRun) {
           // A run seen on a previous tick ended elsewhere: pick up its writes.
           sawRemoteRun = false;
@@ -1121,6 +1138,7 @@ export default function ProjectPage() {
         }
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") return;
+        failedSubscribesRef.current.set(runId, Date.now());
         pushChatError(formatStreamError(err, streamErrLabels), {
           kind: "subscribe",
           runId,
@@ -1136,6 +1154,7 @@ export default function ProjectPage() {
     },
     [chatId, handleStreamEvent, locale, projectId, pushChatError, seedStreamState, streamErrLabels, t],
   );
+  subscribeRunEventsRef.current = subscribeRunEvents;
 
   useEffect(() => {
     const rid = restoredBgRunRef.current;
@@ -1576,6 +1595,20 @@ export default function ProjectPage() {
           /* ignore */
         }
         if (res.status === 400) {
+          // "run_invalid_state" usually means the run is STILL EXECUTING and
+          // the UI simply lost its stream: reattach instead of wiping the
+          // plan (which flickered the panel and re-enabled the composer).
+          try {
+            const active = await api<{ id: string; status: string } | null>(
+              `/projects/${projectId}/chats/${chatId}/runs/active`,
+            );
+            if (active?.id && active.status === "running") {
+              await subscribeRunEvents(active.id);
+              return;
+            }
+          } catch {
+            /* fall through to the invalid-plan reset */
+          }
           setPlanTasks([]);
           setPlanNeedsConfirm(false);
           setActiveRunId(null);

--- a/apps/web/components/builder/PreviewPane.tsx
+++ b/apps/web/components/builder/PreviewPane.tsx
@@ -204,7 +204,10 @@ export function PreviewPane({
 
     window.addEventListener("message", onMessage);
     const t = window.setTimeout(() => {
-      void pushRender(targetOrigin);
+      // Only push once the iframe actually loaded the runner: posting into a
+      // not-yet-navigated frame (about:blank inherits the parent origin)
+      // spammed "target origin does not match" console errors on every push.
+      if (runnerReadyRef.current) void pushRender(targetOrigin);
     }, 400);
     return () => {
       window.removeEventListener("message", onMessage);
@@ -216,6 +219,7 @@ export function PreviewPane({
   useEffect(() => {
     setLoadError(false);
     appMountedRef.current = false;
+    runnerReadyRef.current = false;
   }, [previewSrc]);
 
   function clearNavigateRetries() {


### PR DESCRIPTION
## Problemes
- Cliquer 'Resume plan' pendant qu'un run tournait encore cote serveur -> 400 run_invalid_state -> plan vide -> re-detection par le poll -> clignotement play/stop en boucle
- Composer restait editable (pas de bouton stop) pendant qu'un plan tournait sans stream local
- Spam console 'target origin does not match' (push bundle dans une iframe pas encore chargee)

## Fixes
- Poll cross-tab: run 'running' sans stream local -> subscribeRunEvents immediat (cool-down 60s apres echec)
- executePlan 400 -> verifie runs/active et se rattache au lieu de vider le plan
- PreviewPane: push du bundle apres load de l'iframe uniquement

## Tests
- 158 vitest OK, tsc OK, lint 0 erreur