### PR TITLE
fix(dashboard): toutes les miniatures de projets s'affichent

### DIFF
--- a/apps/web/components/SiteThumb.tsx
+++ b/apps/web/components/SiteThumb.tsx
@@ -215,6 +215,17 @@ export function SiteThumb({
     };
   }, [frameSrc, visible, frameAllowed]);
 
+  // The compile slot exists to serialize BABEL COMPILATION, not display.
+  // Holding it while the card stays mounted meant only the FIRST card ever
+  // rendered — every other project sat on the gradient placeholder forever.
+  // Release as soon as this card is ready (mounted or grace timeout) so the
+  // next card can start compiling; the rendered iframe stays mounted.
+  useEffect(() => {
+    if (!frameReady || !slotHeldRef.current) return;
+    releaseDraftFrameSlot();
+    slotHeldRef.current = false;
+  }, [frameReady]);
+
   useEffect(() => {
     const el = shellRef.current;
     if (!el) return;


### PR DESCRIPTION
Le slot de compilation (1 iframe draft a la fois, pour serialiser Babel) n'etait libere qu'au demontage de la carte: seule la premiere carte du dashboard rendait sa miniature, les autres restaient sur le placeholder degrade indefiniment.

Fix: liberation du slot des que la carte est prete (forge:mounted ou timeout de grace) - l'iframe rendue reste montee, la suivante compile.

Note: les 404 cdn.simpleicons.org en console viennent du SITE GENERE rendu dans la miniature (slugs d'icones invalides dans le projet), pas de Forge.

Tests: 158 vitest OK, tsc OK