### PR TITLE
fix(runs): course poll/stream (clignotement, composer deverrouille) + fuite forge-write

### DIFF
--- a/apps/web/app/projects/[id]/page.tsx
+++ b/apps/web/app/projects/[id]/page.tsx
@@ -718,7 +718,12 @@ export default function ProjectPage() {
           const failedAt = failedSubscribesRef.current.get(active.id) || 0;
           if (
             active.status === "running" &&
+            // Re-check AFTER the await above: a local stream may have started
+            // while /runs/active was in flight. Subscribing here would abort
+            // it and desync busy/streamActive (flickering panel + unlocked
+            // composer while the plan runs).
             !streamAbortRef.current &&
+            !streamingRunIdRef.current &&
             Date.now() - failedAt > 60_000
           ) {
             void subscribeRunEventsRef.current?.(active.id);
@@ -1145,10 +1150,15 @@ export default function ProjectPage() {
         });
         setPlanNeedsConfirm(true);
       } finally {
-        if (streamAbortRef.current === abortCtrl) streamAbortRef.current = null;
-        if (streamingRunIdRef.current === runId) streamingRunIdRef.current = null;
-        setStreamActive(false);
-        setBusy(false);
+        // Ownership guard — a newer stream may have replaced this one.
+        if (streamAbortRef.current === abortCtrl) {
+          streamAbortRef.current = null;
+          setStreamActive(false);
+          setBusy(false);
+        }
+        if (streamingRunIdRef.current === runId && streamAbortRef.current === null) {
+          streamingRunIdRef.current = null;
+        }
         void refreshRodiumWallet();
       }
     },
@@ -1494,10 +1504,17 @@ export default function ProjectPage() {
         setStreamEffort(null);
         setClarifyQuestions([]);
       } finally {
-        streamAbortRef.current = null;
-        streamingRunIdRef.current = null;
-        setStreamActive(false);
-        setBusy(false);
+        // Only reset shared stream state if WE still own the stream: a
+        // reattach (poll / drop-fallback) may have replaced it, and blindly
+        // clearing busy/streamActive here unlocked the composer and showed
+        // "Resume plan" while the run was still streaming.
+        const ownsStream = streamAbortRef.current === abortCtrl;
+        if (ownsStream) {
+          streamAbortRef.current = null;
+          streamingRunIdRef.current = null;
+          setStreamActive(false);
+          setBusy(false);
+        }
         void refreshRodiumWallet();
       }
     },
@@ -1569,10 +1586,10 @@ export default function ProjectPage() {
       ...prev.filter((s) => s.id !== "plan-exec"),
       { id: "plan-exec", label: t("planStatusStarting"), status: "running" },
     ]);
+    streamAbortRef.current?.abort();
+    const abortCtrl = new AbortController();
+    streamAbortRef.current = abortCtrl;
     try {
-      streamAbortRef.current?.abort();
-      const abortCtrl = new AbortController();
-      streamAbortRef.current = abortCtrl;
       const res = await fetch(
         `${apiBase()}/projects/${projectId}/chats/${chatId}/runs/${activeRunId}/confirm-plan`,
         {
@@ -1652,9 +1669,12 @@ export default function ProjectPage() {
         );
       }
     } finally {
-      streamAbortRef.current = null;
-      setStreamActive(false);
-      setBusy(false);
+      // Ownership guard — a reattached stream may have replaced ours.
+      if (streamAbortRef.current === abortCtrl) {
+        streamAbortRef.current = null;
+        setStreamActive(false);
+        setBusy(false);
+      }
       void refreshRodiumWallet();
     }
   }, [activeRunId, chatId, handleStreamEvent, locale, planTasks, projectId, pushChatError, seedStreamState, streamErrLabels, subscribeRunEvents, t]);

--- a/apps/web/lib/message-segments.test.ts
+++ b/apps/web/lib/message-segments.test.ts
@@ -82,6 +82,15 @@ describe("streaming", () => {
     expect(segments.every((s) => s.kind === "text")).toBe(true);
   });
 
+  it("never leaks a partial opening tag into the prose", () => {
+    for (const tail of ["<forge", "<forge-write", '<forge-write path="src/App.tsx', "</forge-write"]) {
+      const segments = splitMessageSegments(`Voici la suite\n${tail}`);
+      expect(segments).toEqual([{ kind: "text", content: "Voici la suite" }]);
+    }
+    // A real "<" in prose is untouched.
+    expect(splitMessageSegments("a < b")).toEqual([{ kind: "text", content: "a < b" }]);
+  });
+
   it("flips to complete once the closing tag arrives", () => {
     const open = splitMessageSegments('<forge-write path="a.ts">x');
     const closed = splitMessageSegments('<forge-write path="a.ts">x</forge-write>');

--- a/apps/web/lib/message-segments.ts
+++ b/apps/web/lib/message-segments.ts
@@ -39,6 +39,20 @@ function pushText(out: MessageSegment[], buffer: string) {
   if (content) out.push({ kind: "text", content });
 }
 
+/** Drop a PARTIAL forge tag still streaming in at the end of the buffer —
+ *  otherwise the chat briefly shows raw `<forge-write path="…` as prose. */
+function trimPartialTag(buffer: string): string {
+  const lt = buffer.lastIndexOf("<");
+  if (lt === -1) return buffer;
+  const tail = buffer.slice(lt).toLowerCase();
+  if (tail.includes(">")) return buffer; // tag closed — the parser handles it
+  const tags = ["<forge-write", "</forge-write", "<forge-delete", "<forge"];
+  if (tags.some((tag) => tag.startsWith(tail) || tail.startsWith(tag))) {
+    return buffer.slice(0, lt);
+  }
+  return buffer;
+}
+
 export function splitMessageSegments(raw: string): MessageSegment[] {
   const out: MessageSegment[] = [];
   let rest = raw || "";
@@ -52,7 +66,7 @@ export function splitMessageSegments(raw: string): MessageSegment[] {
     const writeAt = write?.index ?? Infinity;
     const delAt = del?.index ?? Infinity;
     if (writeAt === Infinity && delAt === Infinity) {
-      text += rest;
+      text += trimPartialTag(rest);
       break;
     }
 


### PR DESCRIPTION
## Cause racine du clignotement persistant
Le poll cross-tab verifiait streamAbortRef AVANT son await reseau. Si executePlan demarrait pendant l'await, le poll rattachait un second stream qui abortait le premier ; le finally du premier ecrasait busy/streamActive/streamAbortRef -> composer deverrouille, boutons Resume visibles pendant le run, et boucle abort+replay toutes les 10 s (clignotement du plan, replays de preview_refresh).

## Fixes
- Re-verification du stream local apres l'await + garde streamingRunIdRef
- Gardes de propriete dans les finally (sendMessage / executePlan / subscribeRunEvents) : on ne reset l'etat partage que si on possede encore le stream
- message-segments : un tag forge PARTIEL en fin de buffer (`<forge-write path="...`) n'apparait plus en prose pendant le streaming (+ tests)

## Tests
159 vitest OK, tsc OK
