### PR TITLE
fix(api): epuisement du pool DB (Network request failed, runs interrompus) + navigation page picker

### DIFF
--- a/apps/api/app/db.py
+++ b/apps/api/app/db.py
@@ -7,7 +7,19 @@ from app.config import get_settings
 
 settings = get_settings()
 
-engine = create_engine(settings.database_url, pool_pre_ping=True)
+# Pool sized for an SSE-heavy API: streams + background plan jobs are long-
+# lived, and the default 5+10 pool exhausted under a single active plan run
+# (every request then failed with QueuePool timeout → "Network request failed"
+# cascades in the builder). Sessions must still release connections before
+# long awaits — see the `db.commit()` calls ahead of LLM streams.
+engine = create_engine(
+    settings.database_url,
+    pool_pre_ping=True,
+    pool_size=15,
+    max_overflow=25,
+    pool_timeout=10,
+    pool_recycle=1800,
+)
 # expire_on_commit=False avoids DetachedInstanceError when request-scoped
 # User/Settings objects are reused after commits (token refresh, streaming).
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, expire_on_commit=False, bind=engine)

--- a/apps/api/app/routers/chats.py
+++ b/apps/api/app/routers/chats.py
@@ -184,6 +184,9 @@ async def _iter_single_pass(
         model=model,
         surgical_edit=surgical_edit,
     )
+    # End the read transaction: the LLM stream below can run for minutes and
+    # must not pin a pooled DB connection the whole time.
+    db.commit()
     yield push_step("select_files", t("step_select_files", locale), "done")
     yield push_step("generate", t("step_generate_code", locale), "running")
 
@@ -243,6 +246,7 @@ async def _iter_single_pass(
             model=model,
             surgical_edit=surgical_edit,
         )
+        db.commit()
         empty_retry_full: list[str] = []
         try:
             async for chunk in stream_chat_completion(
@@ -298,6 +302,7 @@ async def _iter_single_pass(
             model=model,
             surgical_edit=surgical_edit,
         )
+        db.commit()
         retry_full: list[str] = []
         try:
             async for chunk in stream_chat_completion(
@@ -860,6 +865,8 @@ async def send_message(
             if needs_confirm:
                 return
             history = _history(db, chat_id_pk)
+            # Release the DB connection before relaying the whole run.
+            db.commit()
             spawn_plan_job(
                 run_id=run_pk,
                 user_id=user.id,
@@ -974,6 +981,8 @@ async def submit_clarify(
             history = _history(db, chat_id_pk)
             questions = json.loads(clarify_json) if clarify_json else None
             answers_block = format_answers_for_prompt(answers, questions)
+            # Release the DB connection before relaying the whole run.
+            db.commit()
             spawn_plan_job(
                 run_id=run_pk,
                 user_id=user.id,
@@ -1038,6 +1047,9 @@ async def confirm_plan(
 
     history = _history(db, chat_id_pk)
     user_id = user.id
+    # End the implicit read transaction and release the connection: the SSE
+    # relay below runs for the whole plan and must not pin the pool.
+    db.close()
 
     spawn_plan_job(
         run_id=run_pk,
@@ -1071,6 +1083,9 @@ async def stream_run_events(
     """Replay + live SSE for a background plan run (reconnect after refresh)."""
     locale = resolve_locale(request)
     _owned_run(db, user, project_id, chat_id, run_id, locale)
+    # The stream below can live for the whole run: release the DB connection
+    # NOW or every reconnect pins one until the pool is exhausted.
+    db.close()
     after = 0
     try:
         after = max(0, int(request.query_params.get("after") or 0))
@@ -1278,6 +1293,8 @@ async def branch_messages(
             if needs_confirm:
                 return
             history = _history(db, chat_id_pk)
+            # Release the DB connection before relaying the whole run.
+            db.commit()
             spawn_plan_job(
                 run_id=run_pk,
                 user_id=user.id,

--- a/apps/api/app/services/orchestration/dispatcher.py
+++ b/apps/api/app/services/orchestration/dispatcher.py
@@ -201,6 +201,8 @@ async def _stream_verify_repair(
         surgical_edit=surgical_edit,
         focus_paths=focus_paths,
     )
+    if db is not None:
+        db.commit()  # release the pooled connection before the LLM stream
     current_auth = await resolve_auth() if resolve_auth else auth
     repair_buf: list[str] = []
     try:
@@ -339,6 +341,10 @@ async def run_plan_tasks(
             # from stale conversation memory.
             focus_paths=[str(f) for f in (task.get("files") or []) if isinstance(f, str)],
         )
+        # End the read transaction: the LLM stream below can run for minutes
+        # and must not pin a pooled DB connection the whole time.
+        if db is not None:
+            db.commit()
         yield push_step("select_files", t("step_select_files", locale), "done")
         yield push_step("generate", t("step_generate", locale), "running")
 

--- a/apps/api/runtime/public/bridge.js
+++ b/apps/api/runtime/public/bridge.js
@@ -633,6 +633,21 @@
     return false;
   }
 
+  /** Loose slug equality: exact, containment, or long-enough common prefix.
+   *  Bridges accents/plural/language drift between route slugs and nav labels
+   *  ("activities" route vs "Activités" label → activites, prefix "activit"). */
+  function slugsClose(a, b) {
+    if (!a || !b) return false;
+    if (a === b) return true;
+    if (a.length >= 4 && b.indexOf(a) === 0) return true;
+    if (b.length >= 4 && a.indexOf(b) === 0) return true;
+    var min = Math.min(a.length, b.length);
+    if (min < 4) return false;
+    var common = 0;
+    while (common < min && a.charAt(common) === b.charAt(common)) common++;
+    return common >= Math.max(4, Math.ceil(min * 0.7));
+  }
+
   function tryNavigateDedicatedPage(pageKey, normalized) {
     var keyLower = pageKey.toLowerCase();
     var forgePages = document.querySelectorAll("[data-forge-page]");
@@ -648,6 +663,19 @@
       }
     }
 
+    // Deterministic: anchors whose href targets the requested route
+    // ("/activities", "#/activities", "#activities").
+    var anchors = document.querySelectorAll("a[href]");
+    for (var h = 0; h < anchors.length; h++) {
+      var href = (anchors[h].getAttribute("href") || "").trim();
+      var hrefNorm = href.replace(/^#\/?/, "/").replace(/\/+$/, "") || "/";
+      if (hrefNorm === normalized) {
+        safeClick(anchors[h]);
+        reportPreviewPath(normalized);
+        return true;
+      }
+    }
+
     var container = findPageContainer(pageKey);
     if (container) {
       var clickable = container.querySelector("a, button, [role='button']");
@@ -657,16 +685,19 @@
       return true;
     }
 
-    // The #1 generated pattern: a nav control labeled exactly like the page
-    // ("Contact", "À propos"). Buttons drive setPage() state; anchors drive a
-    // router — safeClick blocks the native navigation that would leave
-    // /runner/ while letting SPA handlers run.
-    var navScopes = document.querySelectorAll("nav, header, [class*='nav']");
+    // The #1 generated pattern: a nav control labeled like the page
+    // ("Contact", "À propos", "Activités"). Buttons drive setPage() state;
+    // anchors drive a router — safeClick blocks native navigation. Dashboards
+    // put their nav in sidebars/menus, not only <nav>.
+    var navScopes = document.querySelectorAll(
+      "nav, header, aside, [role='navigation'], [class*='nav'], [class*='sidebar'], [class*='menu']",
+    );
+    var wantedSlug = pageKeySlug(pageKey);
     for (var s = 0; s < navScopes.length; s++) {
       var controls = navScopes[s].querySelectorAll("a, button, [role='button']");
       for (var c = 0; c < controls.length; c++) {
         var ctl = controls[c];
-        if (slugify(ctl.textContent) === pageKeySlug(pageKey)) {
+        if (slugsClose(slugify(ctl.textContent), wantedSlug)) {
           safeClick(ctl);
           reportPreviewPath(normalized);
           return true;


### PR DESCRIPTION
## Cause racine confirmee (logs CloudWatch prod)
`sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00` en boucle sur /ecs/forge-api.

Chaque stream SSE (duree d'un run entier) et chaque generation LLM gardaient une connexion DB checked-out via une transaction de lecture implicite jamais terminee. Pool par defaut 5+10 -> epuise des le premier plan actif -> TOUTES les requetes echouent ("Network request failed" dans le chat, runs interrompus apres la tache 1, reattach en boucle = clignotement, preview/start en 500).

## Fixes
- db.py : pool_size=15, max_overflow=25, pool_timeout=10, pool_recycle=1800
- Liberation des connexions avant les attentes longues :
  - GET /runs/{id}/events : db.close() avant le stream (chaque reconnexion pinnait une connexion)
  - confirm-plan / messages / clarify / branch : commit apres lecture history, avant le relais SSE du run
  - dispatcher + single-pass : commit apres build_llm_messages, avant chaque stream LLM (les generations duraient des minutes avec une transaction ouverte)

## Bonus : navigation du page picker dans la preview (bridge.js)
- Correspondance deterministe par href (/route, #/route, #route)
- Scopes de nav elargis (aside, sidebar, menu, role=navigation) pour les dashboards
- Correspondance floue label<->slug (accents / pluriel / FR<->EN, ex. "Activites" <-> /activities)

## Tests
219 pytest OK, ruff OK, bridge.js syntax OK
