### PR TITLE
fix(auth): prevent double OIDC callback and uncaught session hydrate

### DIFF
--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { AuthCallbackScreen } from "@/components/auth/AuthCallbackScreen";
 import { api, setToken } from "@/lib/api";
@@ -11,6 +11,8 @@ function CallbackInner() {
   const params = useSearchParams();
   const { t } = useI18n();
   const [error, setError] = useState<string | null>(null);
+  // React Strict Mode remounts effects twice; an OIDC code is single-use.
+  const startedRef = useRef(false);
 
   useEffect(() => {
     const code = params.get("code");
@@ -24,17 +26,24 @@ function CallbackInner() {
       setError(t("loginRodiumMissingCode"));
       return;
     }
+    if (startedRef.current) return;
+    startedRef.current = true;
 
     let cancelled = false;
     api<{ access_token: string }>("/auth/rodium/callback", {
       method: "POST",
       body: JSON.stringify({ code, state }),
     })
-      .then((data) => {
+      .then(async (data) => {
         if (cancelled) return;
         setToken(data.access_token);
-        void import("@/lib/session-cache").then(({ ensureSession }) => ensureSession({ force: true }));
-        router.replace("/dashboard");
+        try {
+          const { ensureSession } = await import("@/lib/session-cache");
+          await ensureSession({ force: true });
+        } catch {
+          // Session hydrate is best-effort; dashboard will refresh again.
+        }
+        if (!cancelled) router.replace("/dashboard");
       })
       .catch((err) => {
         if (cancelled) return;


### PR DESCRIPTION
## Summary
- Guard Strict Mode remounts so the OIDC code is exchanged only once
- Await/catch ensureSession so /auth/callback no longer leaves unhandled promise rejections

## Test plan
- [ ] Login via RodiumAi → /auth/callback → dashboard without console Uncaught (in promise)
- [ ] Open a project after login and confirm no auth loop