### PR TITLE
style: ruff-fix auth callback test imports

### DIFF
--- a/apps/api/tests/test_auth_callback_slim.py
+++ b/apps/api/tests/test_auth_callback_slim.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import BackgroundTasks
+
 from app.routers import auth as auth_mod
 from app.schemas import OAuthCallbackRequest
 from app.services.rodium_oidc import NEST_HTTP_TIMEOUT


### PR DESCRIPTION
## Summary
- Fix Ruff I001 import sorting in `tests/test_auth_callback_slim.py` so Deploy API pre-checks pass after #28.

## Test plan
- [x] `ruff check` on the test file
- [ ] Deploy API succeeds on main