### PR TITLE
fix(api): QueuePool leak causing fake CORS / login Network errors

### DIFF
--- a/apps/api/app/db.py
+++ b/apps/api/app/db.py
@@ -15,10 +15,13 @@ settings = get_settings()
 engine = create_engine(
     settings.database_url,
     pool_pre_ping=True,
-    pool_size=15,
-    max_overflow=25,
-    pool_timeout=10,
+    # Chat/plan SSE + background jobs must not starve login/dashboard under load.
+    # Prefer LIFO so bursty traffic reuses hot connections; recycle before NAT/idle drops.
+    pool_size=25,
+    max_overflow=35,
+    pool_timeout=20,
     pool_recycle=1800,
+    pool_use_lifo=True,
 )
 # expire_on_commit=False avoids DetachedInstanceError when request-scoped
 # User/Settings objects are reused after commits (token refresh, streaming).

--- a/apps/api/app/routers/chats.py
+++ b/apps/api/app/routers/chats.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.auth import get_current_user
 from app.config import get_settings
-from app.db import get_db
+from app.db import SessionLocal, get_db
 from app.i18n import resolve_locale, t
 from app.models import AgentRun, Chat, Message, Project, User
 from app.schemas import (
@@ -881,6 +881,7 @@ async def send_message(
             history = _history(db, chat_id_pk)
             # Release the DB connection before relaying the whole run.
             db.commit()
+            db.close()
             spawn_plan_job(
                 run_id=run_pk,
                 user_id=user.id,
@@ -896,10 +897,11 @@ async def send_message(
                 yield chunk
         except Exception as exc:
             try:
-                err_row = db.get(AgentRun, run_pk)
-                if err_row is not None:
-                    err_row.status = "error"
-                    db.commit()
+                with SessionLocal() as err_db:
+                    err_row = err_db.get(AgentRun, run_pk)
+                    if err_row is not None:
+                        err_row.status = "error"
+                        err_db.commit()
             except Exception:
                 pass
             yield _sse({"type": "error", "message": str(exc)[:500]})

--- a/apps/api/app/services/orchestration/plan_persist.py
+++ b/apps/api/app/services/orchestration/plan_persist.py
@@ -142,8 +142,13 @@ def handle_plan_stream_payload(
         persist_plan_error(db, run_pk, payload, locale)
 
 
-def make_progress_cb(db: Session, run_pk: UUID):
+def make_progress_cb(run_pk: UUID):
+    """Checkpoint with a short-lived session — never pin the pool across LLM awaits."""
+
     async def _cb(tasks: list, cursor: int) -> None:
-        checkpoint_plan(db, run_pk, tasks, cursor)
+        from app.db import SessionLocal
+
+        with SessionLocal() as db:
+            checkpoint_plan(db, run_pk, tasks, cursor)
 
     return _cb

--- a/apps/api/app/services/orchestration/plan_worker.py
+++ b/apps/api/app/services/orchestration/plan_worker.py
@@ -52,22 +52,33 @@ async def _execute_plan_job(
     run_queue.clear_run_events(rid)
     clear_cancelled(rid)
     run_queue.claim_run(rid)
-    db = SessionLocal()
-    try:
+
+    # Never hold one Session across LLM awaits — that exhausted QueuePool in prod
+    # (ALB 502 without CORS headers → browser "Network / CORS" errors on login).
+    with SessionLocal() as db:
         user = db.get(User, user_id)
         if user is None:
-            run_queue.publish_run_event(rid, {"type": "error", "message": "User not found", "plan": tasks})
+            run_queue.publish_run_event(
+                rid, {"type": "error", "message": "User not found", "plan": tasks}
+            )
+            run_queue.release_run(rid)
+            _running_tasks.pop(rid, None)
             return
 
-        from app.services.orchestration.plan_persist import (
-            handle_plan_stream_payload,
-            make_progress_cb,
-        )
+    from app.services.orchestration.plan_persist import (
+        handle_plan_stream_payload,
+        make_progress_cb,
+    )
 
-        async def resolve_auth():
-            fresh = db.get(User, user_id) or user
+    async def resolve_auth():
+        with SessionLocal() as db:
+            fresh = db.get(User, user_id)
+            if fresh is None:
+                raise RuntimeError("User not found")
             return await resolve_generation_auth(db, fresh)
 
+    try:
+        initial_auth = await resolve_auth()
         async for chunk in run_plan_tasks(
             project_id=project_id,
             history=history,
@@ -75,33 +86,35 @@ async def _execute_plan_job(
             answers_block=answers_block,
             tasks=tasks,
             model=model,
-            auth=await resolve_auth(),
+            auth=initial_auth,
             resolve_auth=resolve_auth,
-            on_progress=make_progress_cb(db, run_id),
+            on_progress=make_progress_cb(run_id),
             locale=locale,
             run_id=rid,
             user_id=user_id,
-            db=db,
+            db=None,
             step_mode=step_mode,
         ):
             payload = _parse_sse_chunk(chunk)
             if payload:
                 run_queue.publish_run_event(rid, payload)
-                handle_plan_stream_payload(
-                    db,
-                    run_id,
-                    payload,
-                    plan=tasks,
-                    locale=locale,
-                )
+                with SessionLocal() as db:
+                    handle_plan_stream_payload(
+                        db,
+                        run_id,
+                        payload,
+                        plan=tasks,
+                        locale=locale,
+                    )
     except Exception as exc:
         logger.exception("plan job failed run_id=%s", rid)
         try:
-            row = db.get(AgentRun, run_id)
-            if row is not None:
-                row.status = "error"
-                row.plan_json = json.dumps(tasks)
-                db.commit()
+            with SessionLocal() as db:
+                row = db.get(AgentRun, run_id)
+                if row is not None:
+                    row.status = "error"
+                    row.plan_json = json.dumps(tasks)
+                    db.commit()
         except Exception:
             pass
         run_queue.publish_run_event(
@@ -110,7 +123,6 @@ async def _execute_plan_job(
         )
     finally:
         run_queue.release_run(rid)
-        db.close()
         _running_tasks.pop(rid, None)
 
 


### PR DESCRIPTION
## Summary
- Background plan jobs no longer hold one SQLAlchemy session across LLM awaits (root cause of QueuePool exhaustion).
- Larger DB pool + LIFO; release connection before SSE plan relay.
- Symptom in browser: CORS / Network error on `api-forge.rodiumai.io` while ALB was returning 502 without ACAO headers.

## Test plan
- [ ] Login from https://forge.rodiumai.io/login works (no CORS on `/auth/rodium/start`)
- [ ] Dashboard projects/templates load
- [ ] Deploy API workflow SUCCEEDED; ECS forge-api healthy (desired ≥ 2)
