### PR TITLE
fix(forge): surface missing Rodium API key instead of generic Retry

### DIFF
--- a/apps/api/app/services/llm.py
+++ b/apps/api/app/services/llm.py
@@ -120,6 +120,20 @@ def _raise_rodium_error(response: httpx.Response, locale: Locale) -> None:
 
         raise RodiumError(t("rodium_invalid_key", locale), response.status_code, ERR_INVALID_KEY)
 
+    # Nest/playground returns 404 {"message":"API key not found."} when the
+    # linked key id was deleted or never provisioned — that is a key problem,
+    # not a generic upstream outage (which used to show "Retry" forever).
+    if response.status_code == 404 and (
+        "api key not found" in lower
+        or "key not found" in lower
+        or ("api key" in lower and "not found" in lower)
+        or ("apikey" in lower and "not found" in lower)
+        or ("api_key" in lower and "not found" in lower)
+        or ("clé" in lower and "introuvable" in lower)
+        or ("cle " in lower and "introuvable" in lower)
+    ):
+        raise RodiumError(t("rodium_invalid_key", locale), response.status_code, ERR_INVALID_KEY)
+
     if response.status_code == 402 or "quota" in text.lower() or "balance" in text.lower():
         raise RodiumError(t("rodium_quota", locale), response.status_code, ERR_QUOTA)
 

--- a/apps/api/tests/test_llm_error_codes.py
+++ b/apps/api/tests/test_llm_error_codes.py
@@ -1,0 +1,40 @@
+"""Stable codes from `_raise_rodium_error` — the browser maps each to a CTA."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services.llm import (
+    ERR_INVALID_KEY,
+    ERR_UPSTREAM,
+    RodiumError,
+    _raise_rodium_error,
+)
+
+
+def _response(status: int, body: str) -> httpx.Response:
+    return httpx.Response(status, content=body.encode("utf-8"))
+
+
+def test_api_key_not_found_404_is_invalid_key_not_upstream() -> None:
+    # Nest playground: linked apiKeyId deleted / never provisioned.
+    with pytest.raises(RodiumError) as caught:
+        _raise_rodium_error(
+            _response(404, '{"message":"API key not found.","error":"Not Found","statusCode":404}'),
+            "en",
+        )
+    assert caught.value.code == ERR_INVALID_KEY
+    assert caught.value.status_code == 404
+
+
+def test_unrelated_404_stays_upstream() -> None:
+    with pytest.raises(RodiumError) as caught:
+        _raise_rodium_error(_response(404, '{"message":"Model route missing"}'), "en")
+    assert caught.value.code == ERR_UPSTREAM
+
+
+def test_401_key_rejection_is_invalid_key() -> None:
+    with pytest.raises(RodiumError) as caught:
+        _raise_rodium_error(_response(401, '{"message":"Unauthorized"}'), "fr")
+    assert caught.value.code == ERR_INVALID_KEY

--- a/apps/web/lib/chat-errors.test.ts
+++ b/apps/web/lib/chat-errors.test.ts
@@ -85,6 +85,18 @@ describe("classifying a failure", () => {
     expect(info.action).toEqual({ kind: "open-settings" });
   });
 
+  it("treats Nest 'API key not found' prose as an invalid key, not a Retry outage", () => {
+    // Older API builds mapped 404 key-not-found to upstream → generic
+    // "Generation failed on our side" with Retry. The user just linked their
+    // account and needs settings, not another attempt with the same dead id.
+    const info = classifyChatError(
+      new Error('RodiumAi error (404): {"message":"API key not found.","error":"Not Found","statusCode":404}'),
+    );
+    expect(info.code).toBe("invalid_key");
+    expect(info.labelKey).toBe("streamErrorInvalidKey");
+    expect(info.action).toEqual({ kind: "open-settings" });
+  });
+
   it("offers to resume after a dropped connection — the work survived", () => {
     expect(classifyChatError(new Error("…"), "network").action).toEqual({ kind: "resume-plan" });
     expect(classifyChatError(new Error("…"), "timeout").action).toEqual({ kind: "resume-plan" });

--- a/apps/web/lib/chat-errors.ts
+++ b/apps/web/lib/chat-errors.ts
@@ -121,7 +121,9 @@ function codeFromLooseMessage(raw: string): string | null {
   ) {
     return "auth_expired";
   }
-  if (/invalid or unauthorized rodiumai key|clé rodiumai invalide/i.test(raw)) return "invalid_key";
+  if (/invalid or unauthorized rodiumai key|clé rodiumai invalide|api key not found|key not found/i.test(raw)) {
+    return "invalid_key";
+  }
   if (/entity too large|payload_too_large|payloadtoolarge|too large to send|trop volumineuse/i.test(raw)) {
     return "payload_too_large";
   }

--- a/apps/web/lib/i18n/dictionaries.ts
+++ b/apps/web/lib/i18n/dictionaries.ts
@@ -213,7 +213,7 @@ export const dictionaries = {
     streamErrorAuth:
       "Your RodiumAi connection has expired. Reconnect to keep generating.",
     streamErrorInvalidKey:
-      "The RodiumAi API key is invalid or has been revoked. Pick another one in settings.",
+      "The RodiumAi API key is missing, invalid, or revoked. Open settings to pick or refresh a key.",
     streamErrorTimeout:
       "The model stopped responding. The work already done is saved — you can pick up where it stopped.",
     streamErrorTooLarge:
@@ -883,7 +883,7 @@ export const dictionaries = {
     streamErrorAuth:
       "Votre connexion RodiumAi a expiré. Reconnectez-vous pour continuer à générer.",
     streamErrorInvalidKey:
-      "La clé API RodiumAi est invalide ou a été révoquée. Choisissez-en une autre dans les réglages.",
+      "La clé API RodiumAi est absente, invalide ou révoquée. Ouvrez les réglages pour en choisir ou en rafraîchir une.",
     streamErrorTimeout:
       "Le modèle a cessé de répondre. Le travail déjà fait est conservé — vous pouvez reprendre où ça s'est arrêté.",
     streamErrorTooLarge:


### PR DESCRIPTION
## Summary
- Map Nest `404 API key not found` to `invalid_key` (was falling through to `upstream` → generic Retry).
- Classify the same prose on the web as a fallback.
- Clearer EN/FR copy + CTA **Open settings**.

## Test plan
- [ ] With a deleted/unprovisioned linked key id, generation shows invalid-key message + Open settings (not Retry)
- [ ] Unrelated 404 still maps to upstream
- [ ] `pytest tests/test_llm_error_codes.py` and `vitest lib/chat-errors.test.ts` green
- [ ] After merge: Deploy API + Amplify web
