### PR TITLE
feat(auth): Google-only sign-in on login/register

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,10 +104,10 @@ SMTP_PORT=1025
 FORGE_WEB_MAILPIT_SMTP_PORT=1026
 FORGE_WEB_MAILPIT_UI_PORT=8026
 
-# ── Google / GitHub sign-in (optional) ─────────────────────────────────────
-# Leave empty and the social buttons are not rendered at all. To enable them,
-# create a Firebase project, turn on the Google and GitHub providers, and fill
-# both the server credentials and the NEXT_PUBLIC_* pair below.
+# ── Google sign-in (optional) ──────────────────────────────────────────────
+# Leave empty and the Google button is not rendered. To enable it, reuse the
+# same Firebase project as rodiumai_user, enable Google only, authorize
+# forge.rodiumai.io, and fill both the server credentials and NEXT_PUBLIC_*.
 FIREBASE_PROJECT_ID=
 FIREBASE_CLIENT_EMAIL=
 # Paste the service-account private key on one line, with literal \n escapes.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ CI runs on exactly these versions. Older runtimes may build locally and still
 fail CI — `ruff` targets `py312` and several dependencies are version-sensitive.
 
 > **Sign-in works out of the box.** Forge has its own accounts —
-> email/password, plus optional Google and GitHub. Nothing in this repository
+> email/password, plus optional Google. Nothing in this repository
 > depends on a service you cannot run. "Continue with RodiumAI" is an extra
 > that appears only when you configure the OIDC client; with
 > `RODIUM_OIDC_CLIENT_ID` empty (the default) the button is simply hidden.
@@ -116,9 +116,12 @@ field confirms it before you rely on it.
 `https://api.rodiumai.io/v1`, is right for a key from rodiumai.io; change it
 only if you run your own gateway.
 
-Google and GitHub sign-in are optional: fill in the `FIREBASE_*` and
-`NEXT_PUBLIC_FIREBASE_*` values to enable them. Leave them empty and the
-buttons are not rendered.
+Google sign-in is optional: fill in the `FIREBASE_*` (API) and
+`NEXT_PUBLIC_FIREBASE_*` (web build) values to enable the Google button on
+`/login` and `/register`. Leave them empty and the button is not rendered.
+Reuse the same Firebase web app as the RodiumAI user dashboard; enable
+**Google** only in the Firebase console and add `forge.rodiumai.io` under
+Authorized domains. GitHub is not offered in the Forge UI.
 
 ## Hybrid development (Docker infra + local api/web)
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -17,9 +17,12 @@ NEXT_PUBLIC_RODIUM_USER_APP_URL=http://localhost:3000
 # NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 # NEXT_PUBLIC_POSTHOG_ENABLED=false
 
-# ── Google / GitHub sign-in (optional) ─────────────────────────────────────
-# All four must be present or the social buttons are not rendered — a clone
+# ── Google sign-in (optional) ──────────────────────────────────────────────
+# All four must be present or the Google button is not rendered — a clone
 # should never show a sign-in option the API would answer with 503.
+# Use the same Firebase web app as rodiumai_user; enable Google only in the
+# Firebase console (GitHub is not offered in Forge UI).
+# Authorized domains must include forge.rodiumai.io (and localhost for dev).
 NEXT_PUBLIC_FIREBASE_API_KEY=
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -5,7 +5,7 @@
  *
  * "Continue with RodiumAi" stays the primary action — on the hosted instance
  * it is the path that brings a wallet and a generation key with it. Below it
- * sit the options that work without RodiumAi at all: Google, GitHub, and
+ * sit the options that work without RodiumAi at all: Google and
  * email/password. On a clone the RodiumAi button is hidden (the API answers
  * 503 without an OIDC client id), so the local options become the whole page.
  *

--- a/apps/web/components/auth/SocialButtons.test.tsx
+++ b/apps/web/components/auth/SocialButtons.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@/lib/firebase", () => ({
   get firebaseEnabled() {
     return state.enabled;
   },
-  signInWithProvider: vi.fn(async () => "id-token"),
+  signInWithGoogle: vi.fn(async () => "id-token"),
   socialErrorKey: (error: unknown) =>
     (error as { code?: string })?.code === "auth/popup-closed-by-user"
       ? null
@@ -28,7 +28,7 @@ const apiModule = await import("@/lib/api");
 beforeEach(() => {
   state.enabled = true;
   vi.mocked(apiModule.api).mockResolvedValue({ access_token: "jwt" });
-  vi.mocked(firebase.signInWithProvider).mockResolvedValue("id-token");
+  vi.mocked(firebase.signInWithGoogle).mockResolvedValue("id-token");
 });
 
 describe("SocialButtons", () => {
@@ -41,10 +41,10 @@ describe("SocialButtons", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("offers Google and GitHub once configured", () => {
+  it("offers Google only once configured", () => {
     renderWithProviders(<SocialButtons onSuccess={vi.fn()} onError={vi.fn()} />);
     expect(screen.getByText(/google/i)).toBeInTheDocument();
-    expect(screen.getByText(/github/i)).toBeInTheDocument();
+    expect(screen.queryByText(/github/i)).not.toBeInTheDocument();
   });
 
   it("exchanges the ID token and stores the session", async () => {
@@ -63,14 +63,14 @@ describe("SocialButtons", () => {
 
   it("stays silent when the user just closes the popup", async () => {
     const onError = vi.fn();
-    vi.mocked(firebase.signInWithProvider).mockRejectedValue({
+    vi.mocked(firebase.signInWithGoogle).mockRejectedValue({
       code: "auth/popup-closed-by-user",
     });
 
     renderWithProviders(<SocialButtons onSuccess={vi.fn()} onError={onError} />);
-    fireEvent.click(screen.getByText(/github/i));
+    fireEvent.click(screen.getByText(/google/i));
 
-    await waitFor(() => expect(firebase.signInWithProvider).toHaveBeenCalled());
+    await waitFor(() => expect(firebase.signInWithGoogle).toHaveBeenCalled());
     expect(onError).not.toHaveBeenCalled();
   });
 

--- a/apps/web/components/auth/SocialButtons.tsx
+++ b/apps/web/components/auth/SocialButtons.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 /**
- * Google and GitHub sign-in.
+ * Google sign-in (Firebase popup → Forge `/auth/oauth/firebase`).
  *
  * Renders nothing when Firebase is not configured. That is the whole point:
  * a fresh clone has no `NEXT_PUBLIC_FIREBASE_*`, so it shows email/password
- * only rather than two buttons the server would answer with 503.
+ * only rather than a button the server would answer with 503.
+ *
+ * GitHub is intentionally not offered on login/register — Google only.
  */
 
 import { useState } from "react";
 
 import { api, setToken, type ApiError } from "@/lib/api";
-import { firebaseEnabled, signInWithProvider, socialErrorKey, type SocialProvider } from "@/lib/firebase";
+import { firebaseEnabled, signInWithGoogle, socialErrorKey } from "@/lib/firebase";
 import { useI18n } from "@/lib/i18n/I18nProvider";
 import type { MessageKey } from "@/lib/i18n/dictionaries";
 
@@ -27,14 +29,14 @@ export function SocialButtons({
   disabled?: boolean;
 }) {
   const { t } = useI18n();
-  const [busy, setBusy] = useState<SocialProvider | null>(null);
+  const [busy, setBusy] = useState(false);
 
   if (!firebaseEnabled) return null;
 
-  async function run(provider: SocialProvider) {
-    setBusy(provider);
+  async function run() {
+    setBusy(true);
     try {
-      const idToken = await signInWithProvider(provider);
+      const idToken = await signInWithGoogle();
       const data = await api<TokenResponse>("/auth/oauth/firebase", {
         method: "POST",
         body: JSON.stringify({ id_token: idToken }),
@@ -55,7 +57,7 @@ export function SocialButtons({
         // `null` = the user closed the popup. Not an error worth showing.
         if (key) onError(t(key as MessageKey));
       }
-      setBusy(null);
+      setBusy(false);
     }
   }
 
@@ -64,20 +66,12 @@ export function SocialButtons({
       <button
         type="button"
         className="btn btn-ghost auth-social-btn"
-        disabled={disabled || busy !== null}
-        onClick={() => void run("google")}
+        disabled={disabled || busy}
+        onClick={() => void run()}
+        data-testid="auth-google"
       >
         <GoogleMark />
         {t("authContinueWithGoogle")}
-      </button>
-      <button
-        type="button"
-        className="btn btn-ghost auth-social-btn"
-        disabled={disabled || busy !== null}
-        onClick={() => void run("github")}
-      >
-        <GithubMark />
-        {t("authContinueWithGithub")}
       </button>
     </div>
   );
@@ -101,17 +95,6 @@ function GoogleMark() {
       <path
         fill="#EA4335"
         d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.43 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58Z"
-      />
-    </svg>
-  );
-}
-
-function GithubMark() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-      <path
-        fill="currentColor"
-        d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.4 7.4 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
       />
     </svg>
   );

--- a/apps/web/lib/firebase.ts
+++ b/apps/web/lib/firebase.ts
@@ -1,19 +1,17 @@
 /**
- * Firebase client SDK — popup sign-in with Google and GitHub.
+ * Firebase client SDK — Google popup sign-in for Forge login/register.
  *
- * Same shape as the RodiumAi user app, on purpose: the browser collects an ID
- * token and posts it to `POST /auth/oauth/firebase`, which verifies it with
- * the Admin SDK. No provider secret ever reaches this bundle, and there is no
- * second OAuth callback route to maintain.
+ * Same shape as the RodiumAi user app: the browser collects an ID token and
+ * posts it to `POST /auth/oauth/firebase`, which verifies it with the Admin
+ * SDK. No provider secret reaches this bundle.
  *
  * `firebaseEnabled` is the switch that keeps a fresh clone honest. With the
- * `NEXT_PUBLIC_FIREBASE_*` vars unset it is false, the buttons are not
+ * `NEXT_PUBLIC_FIREBASE_*` vars unset it is false, the Google button is not
  * rendered, and nobody clicks an option the server would answer with 503.
  */
 
 import { getApp, getApps, initializeApp, type FirebaseApp } from "firebase/app";
 import {
-  GithubAuthProvider,
   GoogleAuthProvider,
   getAuth,
   signInWithPopup,
@@ -34,8 +32,6 @@ export const firebaseEnabled: boolean = Boolean(
     firebaseConfig.appId,
 );
 
-export type SocialProvider = "google" | "github";
-
 function firebaseApp(): FirebaseApp {
   if (!firebaseEnabled) throw new Error("firebase_not_configured");
   // getApps() guards against double-init across HMR and multiple importers.
@@ -48,29 +44,28 @@ function firebaseAuth(): Auth {
 }
 
 /**
- * Open the provider popup and return a freshly-minted ID token.
+ * Open the Google popup and return a freshly-minted ID token.
  *
  * `forceRefresh` matters: a token cached from an earlier session can be close
  * enough to expiry that it fails verification server-side by the time it
  * arrives.
  */
-export async function signInWithProvider(provider: SocialProvider): Promise<string> {
+export async function signInWithGoogle(): Promise<string> {
   const auth = firebaseAuth();
-  let authProvider;
-  if (provider === "google") {
-    authProvider = new GoogleAuthProvider();
-    // Otherwise a signed-in browser silently reuses one account, which is
-    // baffling for anyone with two.
-    authProvider.setCustomParameters({ prompt: "select_account" });
-  } else {
-    authProvider = new GithubAuthProvider();
-    // GitHub hides the address unless asked; without it the server has no
-    // email to key the account on and refuses the sign-in.
-    authProvider.addScope("read:user");
-    authProvider.addScope("user:email");
-  }
+  const authProvider = new GoogleAuthProvider();
+  // Otherwise a signed-in browser silently reuses one account, which is
+  // baffling for anyone with two.
+  authProvider.setCustomParameters({ prompt: "select_account" });
   const credential = await signInWithPopup(auth, authProvider);
   return credential.user.getIdToken(true);
+}
+
+/** @deprecated Prefer `signInWithGoogle`. Kept for older call sites. */
+export async function signInWithProvider(provider: "google"): Promise<string> {
+  if (provider !== "google") {
+    throw new Error("unsupported_social_provider");
+  }
+  return signInWithGoogle();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Show a single **Continue with Google** button on Forge `/login` and `/register` (GitHub removed from UI).
- Docs/env examples updated for Google-only Firebase setup.
- Prod Amplify already has `NEXT_PUBLIC_FIREBASE_*`; API ECS has `FIREBASE_*`.

## Test plan
- [ ] Open https://forge.rodiumai.io/login after Amplify deploy
- [ ] Google button visible; GitHub absent
- [ ] Google popup sign-in works end-to-end
