### PR TITLE
fix(dashboard): miniatures JPEG — plus de freeze OOM

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -33,7 +33,9 @@ PREVIEW_PUBLIC_PORT=3100
 PREVIEW_PUBLIC_SCHEME=http
 # vite | babel_runner (default: Babel/ESM â€” no Vite process)
 # vite | esm (default: Babel transform publish â€” no vite build)
-RUNNER_PARENT_ORIGINS=http://localhost:3100,http://127.0.0.1:3100
+# Comma-separated origins allowed to receive runner postMessage (builder + dashboard).
+# Production must include the Amplify web origin, e.g. https://forge.rodiumai.io
+RUNNER_PARENT_ORIGINS=http://localhost:3100,http://127.0.0.1:3100,https://forge.rodiumai.io
 
 OBJECT_STORE_PROVIDER=s3_compatible
 OBJECT_STORE_ENDPOINT=http://127.0.0.1:9000

--- a/apps/api/app/routers/preview.py
+++ b/apps/api/app/routers/preview.py
@@ -30,7 +30,7 @@ _DRAFT_THUMB_CACHE: dict[str, tuple[float, str]] = {}
 _DRAFT_THUMB_TTL_S = 90.0
 _DRAFT_THUMB_CACHE_MAX = 40
 # Bump when runner shell / basename injection changes — avoids stale thumb HTML.
-_DRAFT_THUMB_CACHE_VERSION = 2
+_DRAFT_THUMB_CACHE_VERSION = 3
 
 
 class SourceBundle(BaseModel):

--- a/apps/api/app/services/preview_babel.py
+++ b/apps/api/app/services/preview_babel.py
@@ -91,8 +91,8 @@ def render_runner_shell(
 </head>
 <body>
   <div id="root"></div>
-  <script src="/runner/bridge.js?v=imports-fix1"></script>
-  <script type="module" src="/runner/runner.js?v=imports-fix1"></script>
+  <script src="/runner/bridge.js?v=thumb-snap1"></script>
+  <script type="module" src="/runner/runner.js?v=thumb-snap1"></script>
 </body>
 </html>
 """

--- a/apps/api/runtime/public/runner.js
+++ b/apps/api/runtime/public/runner.js
@@ -39,6 +39,25 @@ const send = (payload) => {
   }
 };
 
+/** Thumb snapshots must reach the dashboard even if RUNNER_PARENT_ORIGINS
+ *  was misconfigured in prod — the embedder already passed parent_origin. */
+const sendThumb = (payload) => {
+  let target = PARENT_ORIGIN;
+  if (!target) {
+    try {
+      target = new URLSearchParams(location.search).get("parent_origin") || "";
+    } catch {
+      target = "";
+    }
+  }
+  if (!target) return;
+  try {
+    parent.postMessage(payload, target);
+  } catch {
+    /* ignore */
+  }
+};
+
 window.onerror = (message, source, line, column, error) => {
   send({
     type: "forge:error",
@@ -443,6 +462,70 @@ async function waitForFirstPaint(timeoutMs = 8000) {
   } catch {
     /* ignore */
   }
+  // Give remote images a short window; don't block forever (dashboard OOM risk).
+  const imgs = [...document.images];
+  if (imgs.length) {
+    await Promise.race([
+      Promise.all(
+        imgs.map(
+          (img) =>
+            img.complete ||
+            new Promise((resolve) => {
+              img.addEventListener("load", resolve, { once: true });
+              img.addEventListener("error", resolve, { once: true });
+            }),
+        ),
+      ),
+      new Promise((resolve) => setTimeout(resolve, 2500)),
+    ]);
+  }
+}
+
+function isThumbMode() {
+  try {
+    return new URLSearchParams(location.search).get("thumb") === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Dashboard cards must not keep a live React tree. Capture a small JPEG and
+ * post it to the parent so the iframe can be destroyed (prevents Chrome OOM
+ * when many project thumbs mount at once).
+ */
+async function captureThumbSnapshot() {
+  const w = Math.min(window.innerWidth || 1280, 1280);
+  const h = Math.min(window.innerHeight || 800, 800);
+  const scale = 0.4;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(1, Math.round(w * scale));
+  canvas.height = Math.max(1, Math.round(h * scale));
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+
+  try {
+    // Dynamic import only in thumb mode — never ship html2canvas to builder preview.
+    const mod = await import("https://esm.sh/html2canvas@1.4.1");
+    const html2canvas = mod.default || mod;
+    const shot = await html2canvas(document.body, {
+      width: w,
+      height: h,
+      windowWidth: w,
+      windowHeight: h,
+      scale,
+      useCORS: true,
+      allowTaint: true,
+      logging: false,
+      backgroundColor: "#111111",
+    });
+    return shot.toDataURL("image/jpeg", 0.7);
+  } catch {
+    // Fallback: solid frame so the parent can still release the live iframe.
+    ctx.fillStyle = "#111111";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    return canvas.toDataURL("image/jpeg", 0.7);
+  }
 }
 
 async function mount(files, entry, tokensCss, assets) {
@@ -576,6 +659,13 @@ async function mount(files, entry, tokensCss, assets) {
       });
     }
     send({ type: "forge:mounted", entry });
+    if (isThumbMode()) {
+      const dataUrl = await captureThumbSnapshot();
+      if (dataUrl) sendThumb({ type: "forge:thumb-snapshot", dataUrl });
+      // Drop the live tree so the iframe is cheap until the parent removes it.
+      const rootClear = document.getElementById("root");
+      if (rootClear) rootClear.innerHTML = "";
+    }
   } catch (e) {
     send({
       type: "forge:error",
@@ -583,6 +673,15 @@ async function mount(files, entry, tokensCss, assets) {
       message: String(e?.message || e),
       stack: e?.stack,
     });
+    if (isThumbMode()) {
+      // Still release the dashboard slot with a placeholder frame.
+      try {
+        const dataUrl = await captureThumbSnapshot();
+        if (dataUrl) sendThumb({ type: "forge:thumb-snapshot", dataUrl });
+      } catch {
+        /* ignore */
+      }
+    }
     // Keep previous blobs if mount failed
     for (const url of blobUrls.values()) {
       try {

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -568,6 +568,7 @@ function DashboardInner() {
                       frameSrc={thumb.frameSrc}
                       src={thumb.src}
                       authPath={thumb.authPath}
+                      cacheKey={`${p.id}:${p.updated_at || p.created_at}`}
                       title={p.name}
                       className="home-card-thumb"
                     />

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7501,6 +7501,23 @@ body:has(.home) [data-next-mark] {
   pointer-events: none;
 }
 
+.site-thumb-snap {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top center;
+  display: block;
+  pointer-events: none;
+  background: #111;
+}
+
+.site-thumb-host {
+  width: var(--thumb-vw, 1280px);
+  height: var(--thumb-vh, 800px);
+}
+
 .site-thumb iframe {
   width: var(--thumb-vw, 1280px);
   height: var(--thumb-vh, 800px);

--- a/apps/web/components/SiteThumb.tsx
+++ b/apps/web/components/SiteThumb.tsx
@@ -1,6 +1,6 @@
 ﻿"use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { apiBase, getToken } from "@/lib/api";
 
 type Props = {
@@ -14,6 +14,11 @@ type Props = {
    * site of a generated project, which has no static preview.html.
    */
   frameSrc?: string | null;
+  /**
+   * Stable id for snapshot reuse across dashboard navigations
+   * (e.g. project id + updated_at). Volatile query params (token) are ignored.
+   */
+  cacheKey?: string | null;
   /**
    * Virtual viewport the page is laid out in before being scaled down to the
    * card. Real sites want a desktop width (1280); template preview.html files
@@ -32,32 +37,104 @@ const HTML_CACHE = new Map<string, CacheEntry>();
 const HTML_TTL_MS = 10 * 60 * 1000;
 const INFLIGHT = new Map<string, Promise<string>>();
 
-/** Dashboard cards: one live draft iframe at a time — Babel in parallel freezes the tab. */
-const DRAFT_FRAME_QUEUE: Array<() => void> = [];
-let draftFramesActive = 0;
-const DRAFT_FRAME_MAX = 1;
+/** JPEG data-URLs for live draft thumbs — never keep live React iframes around. */
+const SNAP_CACHE = new Map<string, string>();
+const SNAP_ORDER: string[] = [];
+const MAX_SNAPS = 20;
+const SNAP_STORAGE_PREFIX = "forge_thumb_snap_v1:";
 
-function acquireDraftFrameSlot(): Promise<void> {
-  if (draftFramesActive < DRAFT_FRAME_MAX) {
-    draftFramesActive += 1;
+/** At most one live draft iframe on the whole page (OOM guard). */
+let liveSlotBusy = false;
+const liveWaiters: Array<() => void> = [];
+
+function acquireLiveSlot(): Promise<void> {
+  if (!liveSlotBusy) {
+    liveSlotBusy = true;
     return Promise.resolve();
   }
   return new Promise((resolve) => {
-    DRAFT_FRAME_QUEUE.push(() => {
-      draftFramesActive += 1;
-      resolve();
-    });
+    liveWaiters.push(resolve);
   });
 }
 
-function releaseDraftFrameSlot() {
-  draftFramesActive = Math.max(0, draftFramesActive - 1);
-  const next = DRAFT_FRAME_QUEUE.shift();
+function releaseLiveSlot() {
+  const next = liveWaiters.shift();
   if (next) next();
+  else liveSlotBusy = false;
 }
 
-function cacheKey(src?: string | null, authPath?: string | null) {
+function htmlCacheKey(src?: string | null, authPath?: string | null) {
   return authPath || src || "";
+}
+
+function snapKey(frameSrc: string, explicit?: string | null): string {
+  if (explicit) return explicit;
+  try {
+    const u = new URL(
+      frameSrc,
+      typeof window !== "undefined" ? window.location.origin : "http://local",
+    );
+    u.searchParams.delete("access_token");
+    u.searchParams.delete("parent_origin");
+    u.searchParams.delete("thumb");
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return frameSrc;
+  }
+}
+
+function touchSnap(key: string) {
+  const idx = SNAP_ORDER.indexOf(key);
+  if (idx >= 0) SNAP_ORDER.splice(idx, 1);
+  SNAP_ORDER.push(key);
+  while (SNAP_ORDER.length > MAX_SNAPS) {
+    const drop = SNAP_ORDER.shift();
+    if (!drop) break;
+    SNAP_CACHE.delete(drop);
+    try {
+      sessionStorage.removeItem(SNAP_STORAGE_PREFIX + drop);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function readSnap(key: string): string | null {
+  const mem = SNAP_CACHE.get(key);
+  if (mem) {
+    touchSnap(key);
+    return mem;
+  }
+  try {
+    const stored = sessionStorage.getItem(SNAP_STORAGE_PREFIX + key);
+    if (stored && stored.startsWith("data:image/")) {
+      SNAP_CACHE.set(key, stored);
+      touchSnap(key);
+      return stored;
+    }
+  } catch {
+    /* ignore quota / private mode */
+  }
+  return null;
+}
+
+function writeSnap(key: string, dataUrl: string) {
+  SNAP_CACHE.set(key, dataUrl);
+  touchSnap(key);
+  try {
+    sessionStorage.setItem(SNAP_STORAGE_PREFIX + key, dataUrl);
+  } catch {
+    // Quota exceeded — keep memory copy only; drop oldest storage entries.
+    try {
+      for (const old of [...SNAP_ORDER]) {
+        if (old === key) continue;
+        sessionStorage.removeItem(SNAP_STORAGE_PREFIX + old);
+      }
+      sessionStorage.setItem(SNAP_STORAGE_PREFIX + key, dataUrl);
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 function suppressThumbScroll(html: string): string {
@@ -91,15 +168,35 @@ function writeCache(key: string, html: string) {
 export function invalidateThumbCache(match?: string) {
   if (!match) {
     HTML_CACHE.clear();
+    for (const key of [...SNAP_CACHE.keys()]) {
+      SNAP_CACHE.delete(key);
+      try {
+        sessionStorage.removeItem(SNAP_STORAGE_PREFIX + key);
+      } catch {
+        /* ignore */
+      }
+    }
+    SNAP_ORDER.length = 0;
     return;
   }
   for (const key of [...HTML_CACHE.keys()]) {
     if (key.includes(match)) HTML_CACHE.delete(key);
   }
+  for (const key of [...SNAP_CACHE.keys()]) {
+    if (!key.includes(match)) continue;
+    SNAP_CACHE.delete(key);
+    const idx = SNAP_ORDER.indexOf(key);
+    if (idx >= 0) SNAP_ORDER.splice(idx, 1);
+    try {
+      sessionStorage.removeItem(SNAP_STORAGE_PREFIX + key);
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 async function fetchThumbHtml(src?: string | null, authPath?: string | null): Promise<string> {
-  const key = cacheKey(src, authPath);
+  const key = htmlCacheKey(src, authPath);
   const cached = readCache(key);
   if (cached) return cached;
 
@@ -143,88 +240,42 @@ async function fetchThumbHtml(src?: string | null, authPath?: string | null): Pr
   }
 }
 
+function createLiveIframe(frameSrc: string, title?: string): HTMLIFrameElement {
+  const iframe = document.createElement("iframe");
+  iframe.title = title || "Preview";
+  iframe.tabIndex = -1;
+  iframe.setAttribute("scrolling", "no");
+  iframe.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  iframe.src = frameSrc;
+  return iframe;
+}
+
 /**
- * Scaled homepage thumbnail. Project cards use a live draft iframe (queued: one
- * at a time so the dashboard does not run N Babel compiles in parallel).
- * Templates use cached srcDoc.
+ * Project cards: live-render once → JPEG snapshot → destroy iframe.
+ * Templates: cheap srcDoc HTML (cached). Never parks live React apps —
+ * that OOMs Chrome ("Une erreur est survenue") on the dashboard.
  */
 export function SiteThumb({
   src,
   authPath,
   frameSrc,
+  cacheKey: warmCacheKey,
   viewportWidth = 1280,
   viewportHeight = 800,
   title,
   className,
 }: Props) {
   const shellRef = useRef<HTMLDivElement>(null);
-  const frameRef = useRef<HTMLIFrameElement>(null);
-  const key = cacheKey(src, authPath);
+  const hostRef = useRef<HTMLDivElement>(null);
+  const key = htmlCacheKey(src, authPath);
+  const keySnap = frameSrc ? snapKey(frameSrc, warmCacheKey) : "";
   const [visible, setVisible] = useState(false);
   const [html, setHtml] = useState<string | null>(() => (key ? readCache(key) : null));
   const [failed, setFailed] = useState(false);
   const [scale, setScale] = useState(0.25);
-  const [frameReady, setFrameReady] = useState(false);
-  const [frameAllowed, setFrameAllowed] = useState(false);
-  const slotHeldRef = useRef(false);
-
-  useEffect(() => {
-    if (!frameSrc || !visible) {
-      if (slotHeldRef.current) {
-        releaseDraftFrameSlot();
-        slotHeldRef.current = false;
-      }
-      setFrameAllowed(false);
-      return;
-    }
-    let alive = true;
-    void acquireDraftFrameSlot().then(() => {
-      if (!alive) {
-        releaseDraftFrameSlot();
-        return;
-      }
-      slotHeldRef.current = true;
-      setFrameAllowed(true);
-    });
-    return () => {
-      alive = false;
-      if (slotHeldRef.current) {
-        releaseDraftFrameSlot();
-        slotHeldRef.current = false;
-      }
-      setFrameAllowed(false);
-    };
-  }, [frameSrc, visible]);
-
-  useEffect(() => {
-    if (!frameSrc || !visible || !frameAllowed) {
-      setFrameReady(false);
-      return;
-    }
-    setFrameReady(false);
-    function onMessage(e: MessageEvent) {
-      if (!frameRef.current || e.source !== frameRef.current.contentWindow) return;
-      const type = e.data && typeof e.data === "object" ? e.data.type : "";
-      if (type === "forge:mounted") setFrameReady(true);
-    }
-    window.addEventListener("message", onMessage);
-    const grace = window.setTimeout(() => setFrameReady(true), 12000);
-    return () => {
-      window.removeEventListener("message", onMessage);
-      window.clearTimeout(grace);
-    };
-  }, [frameSrc, visible, frameAllowed]);
-
-  // The compile slot exists to serialize BABEL COMPILATION, not display.
-  // Holding it while the card stays mounted meant only the FIRST card ever
-  // rendered — every other project sat on the gradient placeholder forever.
-  // Release as soon as this card is ready (mounted or grace timeout) so the
-  // next card can start compiling; the rendered iframe stays mounted.
-  useEffect(() => {
-    if (!frameReady || !slotHeldRef.current) return;
-    releaseDraftFrameSlot();
-    slotHeldRef.current = false;
-  }, [frameReady]);
+  const [snapshot, setSnapshot] = useState<string | null>(() =>
+    frameSrc && keySnap ? readSnap(keySnap) : null,
+  );
 
   useEffect(() => {
     const el = shellRef.current;
@@ -258,6 +309,81 @@ export function SiteThumb({
     io.observe(el);
     return () => io.disconnect();
   }, []);
+
+  // Live draft → one-at-a-time capture → static image.
+  useLayoutEffect(() => {
+    if (!frameSrc || !visible || snapshot) return;
+    const host = hostRef.current;
+    if (!host) return;
+
+    let cancelled = false;
+    let iframe: HTMLIFrameElement | null = null;
+    let graceTimer = 0;
+    let slotHeld = false;
+    let onMessage: ((e: MessageEvent) => void) | null = null;
+
+    const dropLive = () => {
+      window.clearTimeout(graceTimer);
+      if (onMessage) {
+        window.removeEventListener("message", onMessage);
+        onMessage = null;
+      }
+      if (iframe) {
+        try {
+          iframe.remove();
+        } catch {
+          /* ignore */
+        }
+        iframe = null;
+      }
+      host.replaceChildren();
+      if (slotHeld) {
+        slotHeld = false;
+        releaseLiveSlot();
+      }
+    };
+
+    void (async () => {
+      await acquireLiveSlot();
+      slotHeld = true;
+      if (cancelled) {
+        dropLive();
+        return;
+      }
+
+      // Another card may have filled the cache while we waited.
+      const raced = readSnap(keySnap);
+      if (raced) {
+        setSnapshot(raced);
+        dropLive();
+        return;
+      }
+
+      iframe = createLiveIframe(frameSrc, title);
+      host.replaceChildren(iframe);
+
+      onMessage = (e: MessageEvent) => {
+        if (cancelled || !iframe || e.source !== iframe.contentWindow) return;
+        const type = e.data && typeof e.data === "object" ? e.data.type : "";
+        if (type === "forge:thumb-snapshot" && typeof e.data.dataUrl === "string") {
+          writeSnap(keySnap, e.data.dataUrl);
+          setSnapshot(e.data.dataUrl);
+          dropLive();
+        }
+      };
+      window.addEventListener("message", onMessage);
+
+      // If capture never arrives, drop the live frame so we don't OOM.
+      graceTimer = window.setTimeout(() => {
+        dropLive();
+      }, 20000);
+    })();
+
+    return () => {
+      cancelled = true;
+      dropLive();
+    };
+  }, [frameSrc, visible, snapshot, keySnap, title]);
 
   useEffect(() => {
     let alive = true;
@@ -295,6 +421,8 @@ export function SiteThumb({
     };
   }, [src, authPath, key, visible, frameSrc]);
 
+  const showLiveCapture = Boolean(frameSrc && !snapshot && visible);
+
   return (
     <div
       ref={shellRef}
@@ -308,23 +436,18 @@ export function SiteThumb({
     >
       {frameSrc ? (
         <>
-          {visible && frameAllowed && (
-            <div
-              className="site-thumb-scaler"
-              style={frameReady ? undefined : { visibility: "hidden" }}
-            >
-              <iframe
-                ref={frameRef}
-                src={frameSrc}
-                title={title || "Preview"}
-                tabIndex={-1}
-                scrolling="no"
-                sandbox="allow-scripts allow-same-origin"
-              />
-            </div>
-          )}
-          {visible && (!frameAllowed || !frameReady) && (
-            <div className="site-thumb-fallback is-loading" />
+          {snapshot ? (
+            // eslint-disable-next-line @next/next/no-img-element -- data-URL snapshot, not a remote asset
+            <img className="site-thumb-snap" src={snapshot} alt="" draggable={false} />
+          ) : (
+            <>
+              {showLiveCapture && (
+                <div className="site-thumb-scaler" style={{ visibility: "hidden" }}>
+                  <div className="site-thumb-host" ref={hostRef} />
+                </div>
+              )}
+              <div className="site-thumb-fallback is-loading" />
+            </>
           )}
         </>
       ) : html ? (


### PR DESCRIPTION
## Summary
- Cause: chaque carte projet gardait une iframe Babel/React vivante → Out of Memory, UI figée, puis « Une erreur est survenue »
- Restaure la capture JPEG (1 iframe à la fois) puis destruction de l’iframe
- `sendThumb` fallback via `parent_origin` si `RUNNER_PARENT_ORIGINS` mal configuré

## Test plan
- [ ] Dashboard avec 5+ projets : miniatures apparaissent une par une, pas de freeze
- [ ] Revisit dashboard : snapshots sessionStorage, pas de recompilation
- [ ] Builder preview inchangée (pas de html2canvas hors `?thumb=1`)