### PR TITLE
fix: Vite 5.4.21 + agent SSE hang + sélection dans le fil

### DIFF
--- a/apps/api/app/routers/chats.py
+++ b/apps/api/app/routers/chats.py
@@ -153,8 +153,14 @@ def _generation_auth_resolver(user_id: UUID, locale: str):
             except HTTPException as exc:
                 detail = exc.detail
                 message = detail if isinstance(detail, str) else str(detail)
-                code = "auth_expired" if exc.status_code == 403 else "network"
-                if exc.status_code not in (401, 403, 503):
+                if exc.status_code in (401, 403):
+                    code = "auth_expired"
+                elif exc.status_code == 503:
+                    # Transient Rodium gateway blip — not a dropped Forge socket.
+                    # Mapping this to "network" made the browser reconnect to
+                    # /events for single-pass runs (no buffer) and hang on Analyse.
+                    code = "upstream"
+                else:
                     code = "internal"
                 raise RodiumError(message, exc.status_code, code) from exc
 
@@ -1076,6 +1082,11 @@ async def send_message(
                     err_row = err_db.get(AgentRun, run_pk)
                     if err_row is not None:
                         err_row.status = "error"
+                        record_run_outcome(
+                            err_row,
+                            code=error_code_for(exc),
+                            message=str(exc),
+                        )
                         err_db.commit()
             except Exception:
                 pass

--- a/apps/api/app/services/orchestration/router.py
+++ b/apps/api/app/services/orchestration/router.py
@@ -76,6 +76,9 @@ def strip_attachment_noise(user_text: str) -> str:
         flags=re.I,
     )
     text = re.sub(r"\[Connector:\s*[^\]]+\]", " ", text, flags=re.I)
+    # Preview element-selection chips: long CSS selectors must not push a
+    # one-line visual edit out of the single-pass path (len >= 180 → full plan).
+    text = re.sub(r"\[(?:Sélection|Selection):\s*[^\]]*\]", " ", text, flags=re.I)
     return re.sub(r"\s+", " ", text).strip()
 
 

--- a/apps/api/runtime/packages.json
+++ b/apps/api/runtime/packages.json
@@ -34,7 +34,7 @@
     "class-variance-authority": { "version": "0.7.1", "browser": true },
     "date-fns": { "version": "4.1.0", "browser": true },
 
-    "vite": { "version": "5.4.11", "browser": false },
+    "vite": { "version": "5.4.21", "browser": false },
     "@vitejs/plugin-react": { "version": "4.3.4", "browser": false },
     "typescript": { "version": "5.6.3", "browser": false },
     "@types/react": { "version": "18.3.12", "browser": false },

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1063,6 +1063,43 @@ button.builder-msg-error-link:disabled {
   white-space: normal;
 }
 
+.builder-msg-selection {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  width: fit-content;
+  max-width: 100%;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  background: rgba(37, 99, 235, 0.14);
+  color: #bfdbfe;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.builder-msg-selection-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 999px;
+  background: #2563eb;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0 0.28rem;
+  flex-shrink: 0;
+}
+
+html[data-theme="light"] .builder-msg-selection {
+  color: #1e3a8a;
+  background: rgba(37, 99, 235, 0.1);
+  border-color: rgba(37, 99, 235, 0.35);
+}
+
 .builder-msg-text {
   white-space: pre-wrap;
 }

--- a/apps/web/app/projects/[id]/page.tsx
+++ b/apps/web/app/projects/[id]/page.tsx
@@ -84,6 +84,7 @@ import {
   createProjectRefAttachment,
   parseUserMessageContent,
   revokePromptAttachment,
+  selectionChipLabel,
 } from "@/lib/prompt-attachments";
 import { PAYLOAD_MAX_CHARS, PROMPT_MAX_CHARS } from "@/lib/constants/prompt";
 import { uploadPromptAttachments } from "@/lib/prompt-upload";
@@ -144,6 +145,8 @@ type SendOpts = {
    * Prefer over `editingMessageId` so "Relancer" can fire in the same tick.
    */
   branchFromId?: string | null;
+  /** Explicit selection (resend/edit) — wins over composer state when set. */
+  selection?: ElementSelection | null;
 };
 
 type ChatRetryAction =
@@ -296,17 +299,6 @@ function isNetworkStreamError(err: unknown): boolean {
   if (isRecoverableStreamError(err)) return true;
   const raw = err instanceof Error ? err.message : String(err || "");
   return /aborted/i.test(raw);
-}
-
-/** Human label for the selection chip — never the raw CSS selector path.
- *  Prefers #id, then tag + a short text excerpt (e.g. `nav · “PromptVault”`). */
-function selectionChipLabel(sel: ElementSelection): string {
-  if (sel.id) return `#${sel.id}`;
-  const tag = (sel.tag || "element").toLowerCase();
-  const text = (sel.text || "").trim().replace(/\s+/g, " ");
-  if (!text) return tag;
-  const excerpt = text.length > 28 ? `${text.slice(0, 28)}…` : text;
-  return `${tag} · “${excerpt}”`;
 }
 
 export default function ProjectPage() {
@@ -1416,6 +1408,9 @@ export default function ProjectPage() {
             if (abortCtrl.signal.aborted || (err instanceof Error && err.name === "AbortError")) {
               return;
             }
+            // Terminal SSE error is rethrown by handleStreamEvent after
+            // sawTerminal=true — surface it, do not retry the empty buffer.
+            if (sawTerminal || detached) throw err;
             attempts += 1;
             if (attempts > 5) throw err;
             await new Promise((resolve) => setTimeout(resolve, Math.min(8_000, 500 * 2 ** attempts)));
@@ -1492,6 +1487,17 @@ export default function ProjectPage() {
       setInput(parsed.text);
       setEditingMessageId(messageId);
       setAttachments(restorePromptAttachments(content, messageAttachments));
+      setElementSelection(
+        parsed.selection
+          ? {
+              tag: parsed.selection.tag,
+              id: parsed.selection.id ?? null,
+              className: parsed.selection.className ?? null,
+              selector: parsed.selection.selector || "",
+              text: parsed.selection.text || "",
+            }
+          : null,
+      );
       setError(null);
       textareaRef.current?.focus();
     },
@@ -1502,6 +1508,7 @@ export default function ProjectPage() {
     setEditingMessageId(null);
     setInput("");
     setAttachments([]);
+    setElementSelection(null);
   }, []);
 
   const dismissPlan = useCallback(async () => {
@@ -1626,9 +1633,13 @@ export default function ProjectPage() {
         return;
       }
 
-      const withSelection = elementSelection
-        ? `${formatElementSelectionMarker(elementSelection, t("selectionMarker"))}\n\n${content}`.trim()
-        : content;
+      const withSelection = (() => {
+        const sel =
+          opts.selection !== undefined ? opts.selection : elementSelection;
+        return sel
+          ? `${formatElementSelectionMarker(sel, t("selectionMarker"))}\n\n${content}`.trim()
+          : content;
+      })();
       const built = await buildPromptWithAttachments(withSelection, uploaded, {
         importFiles: t("importFiles"),
         imageAttached: t("promptImageAttached"),
@@ -1748,6 +1759,9 @@ export default function ProjectPage() {
       streamAbortRef.current?.abort();
       const abortCtrl = new AbortController();
       streamAbortRef.current = abortCtrl;
+      // Hoisted so the catch can tell a real transport drop apart from an SSE
+      // `error` frame that handleStreamEvent rethrows as StreamFailure.
+      let sawTerminal = false;
 
       try {
         const endpoint = isBranch
@@ -1803,7 +1817,6 @@ export default function ProjectPage() {
 
         setStreamActive(true);
 
-        let sawTerminal = false;
         await readSseStream(res, async (payloadEvent) => {
           const type = String(payloadEvent.type || "");
           if (type === "done" || type === "error") sawTerminal = true;
@@ -1825,8 +1838,12 @@ export default function ProjectPage() {
         }
         // Network drop mid-run: the backend keeps executing and buffers every
         // event — reattach to the run stream instead of erroring + resetting.
+        // Only when we never saw a terminal SSE frame. handleStreamEvent throws
+        // StreamFailure on `type:error` (sawTerminal already true); treating that
+        // as a transport drop reconnected to /events for single-pass runs that
+        // never publish a buffer — UI stuck on "Analyse de la demande".
         const dropRunId = streamingRunIdRef.current;
-        if (dropRunId && isNetworkStreamError(err)) {
+        if (dropRunId && !sawTerminal && isNetworkStreamError(err)) {
           await subscribeRunEvents(dropRunId);
           return;
         }
@@ -1879,7 +1896,20 @@ export default function ProjectPage() {
       setEditingMessageId(null);
       setInput("");
       setAttachments([]);
-      void sendMessage(parsed.text, restored, { branchFromId: messageId });
+      setElementSelection(null);
+      const selection = parsed.selection
+        ? {
+            tag: parsed.selection.tag,
+            id: parsed.selection.id ?? null,
+            className: parsed.selection.className ?? null,
+            selector: parsed.selection.selector || "",
+            text: parsed.selection.text || "",
+          }
+        : null;
+      void sendMessage(parsed.text, restored, {
+        branchFromId: messageId,
+        selection,
+      });
     },
     [busy, restorePromptAttachments, sendMessage],
   );
@@ -1989,6 +2019,7 @@ export default function ProjectPage() {
     streamAbortRef.current?.abort();
     const abortCtrl = new AbortController();
     streamAbortRef.current = abortCtrl;
+    let sawTerminal = false;
     try {
       const res = await fetch(
         `${apiBase()}/projects/${projectId}/chats/${chatId}/runs/${activeRunId}/confirm-plan`,
@@ -2033,6 +2064,8 @@ export default function ProjectPage() {
       const stateRef = seedStreamState();
       setStreamActive(true);
       await readSseStream(res, async (payloadEvent) => {
+        const type = String(payloadEvent.type || "");
+        if (type === "done" || type === "error") sawTerminal = true;
         handleStreamEvent(payloadEvent, {
           stateRef,
           userPayload: "",
@@ -2045,8 +2078,9 @@ export default function ProjectPage() {
       }
       // Network drop mid-plan: the run keeps going server-side — reattach to
       // the buffered event stream instead of flipping tasks back to pending.
+      // Skip when we already got a terminal SSE error (see sendMessage).
       const dropRunId = streamingRunIdRef.current || activeRunId;
-      if (dropRunId && isNetworkStreamError(err)) {
+      if (dropRunId && !sawTerminal && isNetworkStreamError(err)) {
         await subscribeRunEvents(dropRunId);
         return;
       }
@@ -2609,7 +2643,7 @@ export default function ProjectPage() {
                   >
                     <span className="selection-chip-count">1</span>
                     <span>
-                      {t("selectionBadge")}
+                      {t("selectionMarker")}
                       {` · ${selectionChipLabel(elementSelection)}`}
                     </span>
                     <span aria-hidden>×</span>

--- a/apps/web/components/UserMessageBody.test.tsx
+++ b/apps/web/components/UserMessageBody.test.tsx
@@ -9,6 +9,17 @@ vi.mock("@/lib/media-token", () => ({
   MEDIA_TOKEN_EVENT: "forge:mediatoken",
 }));
 
+vi.mock("@/lib/i18n/I18nProvider", () => ({
+  useI18n: () => ({
+    t: (key: string) =>
+      ({
+        selectionBadge: "1 sélection",
+        selectionMarker: "Sélection",
+      })[key] || key,
+    locale: "fr",
+  }),
+}));
+
 vi.mock("@/lib/api", () => ({
   apiBase: () => "http://localhost:8100",
 }));
@@ -104,5 +115,22 @@ describe("UserMessageBody url-capture thumbs", () => {
     ) as HTMLImageElement | null;
     expect(icon).toBeTruthy();
     expect(icon!.getAttribute("src")).toBe("/favicon.png");
+  });
+
+  it("shows a selection chip parsed from the stored marker", () => {
+    const content = [
+      '[Sélection: div | selector:body > main > .phone | text:"9:41 Good morning"]',
+      "",
+      "change the phone color to pink",
+    ].join("\n");
+    const { container, getByText } = render(
+      <UserMessageBody content={content} projectId="proj-1" />,
+    );
+    expect(container.querySelector(".builder-msg-selection")).toBeTruthy();
+    expect(getByText(/Sélection/i)).toBeTruthy();
+    expect(getByText(/div · “9:41 Good morning”/i)).toBeTruthy();
+    expect(getByText("change the phone color to pink")).toBeTruthy();
+    expect(container.textContent).not.toMatch(/selector:body/);
+    expect(container.textContent).not.toMatch(/11/);
   });
 });

--- a/apps/web/components/UserMessageBody.tsx
+++ b/apps/web/components/UserMessageBody.tsx
@@ -6,8 +6,10 @@ import { Icon } from "@/components/ui/icon";
 import { FileTypeIcon } from "@/components/builder/file-icons";
 import { assetContentUrl, isPrivateUploadUrl, projectPublicUrl } from "@/lib/asset-url";
 import { useMediaToken } from "@/lib/media-token";
+import { useI18n } from "@/lib/i18n/I18nProvider";
 import {
   parseUserMessageContent,
+  selectionChipLabel,
   type MessageAttachment,
 } from "@/lib/prompt-attachments";
 
@@ -121,6 +123,7 @@ function AttachmentThumb({
 export function UserMessageBody({ content, attachments, previewBase, projectId }: Props) {
   // Re-render when the read-only media token arrives so public/ thumbs resolve.
   useMediaToken();
+  const { t } = useI18n();
   const parsed = parseUserMessageContent(content);
   // Prefer parsed (durable object ids / public paths from content) over stale blobs.
   const files =
@@ -144,6 +147,18 @@ export function UserMessageBody({ content, attachments, previewBase, projectId }
 
   return (
     <div className="builder-msg-body builder-msg-user-body">
+      {parsed.selection ? (
+        <div
+          className="builder-msg-selection"
+          title={parsed.selection.selector || undefined}
+        >
+          <span className="builder-msg-selection-count">1</span>
+          <span>
+            {t("selectionMarker")}
+            {` · ${selectionChipLabel(parsed.selection)}`}
+          </span>
+        </div>
+      ) : null}
       {parsed.text ? <div className="builder-msg-text">{parsed.text}</div> : null}
       {files.length > 0 ? (
         <ul className="builder-msg-attachments">

--- a/apps/web/lib/prompt-attachments.selection.test.ts
+++ b/apps/web/lib/prompt-attachments.selection.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatElementSelectionMarker,
+  parseElementSelectionMarker,
+  parseUserMessageContent,
+  selectionChipLabel,
+} from "./prompt-attachments";
+
+describe("element selection markers", () => {
+  it("round-trips format → parse", () => {
+    const marker = formatElementSelectionMarker(
+      {
+        tag: "div",
+        selector: "body > main > .phone",
+        text: 'Hello "world"',
+      },
+      "Sélection",
+    );
+    const parsed = parseElementSelectionMarker(marker);
+    expect(parsed).toEqual({
+      tag: "div",
+      selector: "body > main > .phone",
+      text: "Hello 'world'",
+    });
+  });
+
+  it("exposes selection separately from display text", () => {
+    const raw = [
+      '[Selection: nav | selector:header > nav | text:"PromptVault"]',
+      "",
+      "make this sticky",
+    ].join("\n");
+    const parsed = parseUserMessageContent(raw);
+    expect(parsed.text).toBe("make this sticky");
+    expect(parsed.selection?.tag).toBe("nav");
+    expect(parsed.selection?.selector).toBe("header > nav");
+    expect(selectionChipLabel(parsed.selection!)).toBe('nav · “PromptVault”');
+  });
+});

--- a/apps/web/lib/prompt-attachments.ts
+++ b/apps/web/lib/prompt-attachments.ts
@@ -279,11 +279,59 @@ function intentForImage(prompt: string, name: string): "asset" | "reference" {
   return "reference";
 }
 
+export type ElementSelectionMarker = {
+  tag: string;
+  id?: string | null;
+  className?: string | null;
+  selector: string;
+  text?: string;
+};
+
+const SELECTION_MARKER_RE = /\[(?:Sélection|Selection):\s*[^\]]*\]/gi;
+const SELECTION_MARKER_CAPTURE_RE = /\[(?:Sélection|Selection):\s*([^\]]*)\]/i;
+
+/** Parse the first `[Sélection|Selection: …]` chip embedded in a stored user message. */
+export function parseElementSelectionMarker(raw: string): ElementSelectionMarker | null {
+  const match = (raw || "").match(SELECTION_MARKER_CAPTURE_RE);
+  if (!match) return null;
+  const parts = (match[1] || "")
+    .split(/\s*\|\s*/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (!parts.length) return null;
+  const tag = parts[0] || "element";
+  let selector = "";
+  let text: string | undefined;
+  for (const part of parts.slice(1)) {
+    if (/^selector:/i.test(part)) {
+      selector = part.replace(/^selector:/i, "").trim();
+    } else if (/^text:/i.test(part)) {
+      text = part
+        .replace(/^text:/i, "")
+        .trim()
+        .replace(/^"|"$/g, "");
+    }
+  }
+  return { tag, selector, text };
+}
+
+/** Short human label for a selection chip — never the raw CSS path. */
+export function selectionChipLabel(sel: Pick<ElementSelectionMarker, "tag" | "id" | "text">): string {
+  if (sel.id) return `#${sel.id}`;
+  const tag = (sel.tag || "element").toLowerCase();
+  const text = (sel.text || "").trim().replace(/\s+/g, " ");
+  if (!text) return tag;
+  const excerpt = text.length > 28 ? `${text.slice(0, 28)}…` : text;
+  return `${tag} · “${excerpt}”`;
+}
+
 export function parseUserMessageContent(raw: string): {
   text: string;
   attachments: MessageAttachment[];
+  selection: ElementSelectionMarker | null;
 } {
   const attachments: MessageAttachment[] = [];
+  const selection = parseElementSelectionMarker(raw);
   let text = raw || "";
 
   for (const match of raw.matchAll(ATTACH_IMAGE_RE)) {
@@ -342,15 +390,15 @@ export function parseUserMessageContent(raw: string): {
     .replace(ATTACH_FILES_RE, "")
     .replace(ATTACH_PUBLIC_HINT_RE, "")
     .replace(ATTACH_INSTRUCTION_RE, "")
-    // Legacy prose instructions (older messages) + selection markers stay out of the UI.
-    .replace(/\[(?:Sélection|Selection):\s*[^\]]*\]/gi, "")
+    // Selection is rendered as its own chip — strip the raw marker from the prose.
+    .replace(SELECTION_MARKER_RE, "")
     .replace(/\[Connector:\s*[^\]]+\]/gi, "")
     .replace(/###\s+(?:Markdown file|Fichier Markdown|PDF content|Contenu PDF|Text file|Fichier texte)[^\n]*\n+[\s\S]*?(?=\n###|\n\[|\s*$)/gi, "")
     .replace(/\[(?:PDF attached|PDF joint)[^\]]*\]/gi, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 
-  return { text, attachments };
+  return { text, attachments, selection };
 }
 
 export async function buildPromptWithAttachments(
@@ -428,14 +476,6 @@ export function insertMentionInTextarea(
   const needsSpace = tail && !tail.startsWith("\n");
   return `${head}${head ? " " : ""}${mention}${needsSpace ? " " : ""}${tail}`;
 }
-
-export type ElementSelectionMarker = {
-  tag: string;
-  id?: string | null;
-  className?: string | null;
-  selector: string;
-  text?: string;
-};
 
 export function formatElementSelectionMarker(sel: ElementSelectionMarker, label = "Sélection"): string {
   const parts = [

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forge-web",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forge-web",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
@@ -5197,11 +5197,10 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.15.tgz",
+      "integrity": "sha512-EUBjM+B+lkDE41iE82DDSCfkoPGfXx8IxFxPMjNzm/Uk4xDet77rTN9wqlxlVg71kK7XGuUMv6wUxJUwwv+Xyw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -8992,9 +8991,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "funding": [
         {
           "type": "opencollective",
@@ -9011,7 +9010,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9047,15 +9046,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/posthog-js/node_modules/dompurify": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
-      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/preact": {
@@ -10918,35 +10908,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.17",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,7 +49,8 @@
     "vitest": "^3.2.7"
   },
   "overrides": {
-    "postcss": "8.5.18",
+    "postcss": "^8.5.28",
+    "dompurify": "^3.4.15",
     "sharp": "0.35.0"
   }
 }

--- a/data/templates/astroship-startup/package.json
+++ b/data/templates/astroship-startup/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/atelier-mode/package.json
+++ b/data/templates/atelier-mode/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/aurora-ai/package.json
+++ b/data/templates/aurora-ai/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/bloom-wellness/package.json
+++ b/data/templates/bloom-wellness/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/brutalist-studio/package.json
+++ b/data/templates/brutalist-studio/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/forge-devtools/package.json
+++ b/data/templates/forge-devtools/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/gallery-photos/package.json
+++ b/data/templates/gallery-photos/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/glacier-travel/package.json
+++ b/data/templates/glacier-travel/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/holo-portfolio/package.json
+++ b/data/templates/holo-portfolio/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/kinetic-conf/package.json
+++ b/data/templates/kinetic-conf/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/logsfolio-portfolio/package.json
+++ b/data/templates/logsfolio-portfolio/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/lumen-architecture/package.json
+++ b/data/templates/lumen-architecture/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/mono-journal/package.json
+++ b/data/templates/mono-journal/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/nexora-agency/package.json
+++ b/data/templates/nexora-agency/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/orbit-dashboard/package.json
+++ b/data/templates/orbit-dashboard/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/origami-3d/package.json
+++ b/data/templates/origami-3d/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/podux-podcast/package.json
+++ b/data/templates/podux-podcast/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/pulse-fitness/package.json
+++ b/data/templates/pulse-fitness/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/quantum-consult/package.json
+++ b/data/templates/quantum-consult/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/synthwave-music/package.json
+++ b/data/templates/synthwave-music/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/tailnext-saas/package.json
+++ b/data/templates/tailnext-saas/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/tailstore-shop/package.json
+++ b/data/templates/tailstore-shop/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/terra-eco/package.json
+++ b/data/templates/terra-eco/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }

--- a/data/templates/vertex-crypto/package.json
+++ b/data/templates/vertex-crypto/package.json
@@ -5,5 +5,5 @@
   "type": "module",
   "scripts": { "dev": "vite --host 0.0.0.0 --port 5173", "build": "tsc -b && vite build", "preview": "vite preview --host 0.0.0.0 --port 5173" },
   "dependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" },
-  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.11" }
+  "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "@vitejs/plugin-react": "^4.3.4", "typescript": "^5.6.3", "vite": "^5.4.21" }
 }


### PR DESCRIPTION
## Summary
- **Sécurité :** bump Vite `5.4.21` (templates ×24 + runtime) — GHSA-93m4-6634-74q7.
- **Chat agent :** une erreur SSE terminale (ex. Rodium 503) n’est plus traitée comme une coupure réseau avec reconnexion à `/events` vide (UI figée sur « Analyse de la demande »).
- **Sélection d’élément :** chip visible dans le fil, restaurée à l’édition/relance ; edits courts avec sélection restent en single-pass.

## Test plan
- [ ] CI verte (API + Web)
- [ ] Sélectionner un élément → prompt → chip dans le fil
- [ ] Modifier le message → chip + texte dans le composer
- [ ] Micro-edit → agent dépasse « Analyse » et applique
- [ ] Deploy API (ECS) après merge `main` ; Amplify pour le web
