### PR TITLE
fix(preview): Babel is not defined — ship babel.min.js in API image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,7 +1,7 @@
 # Build from repository root (Forge monorepo):
 #   docker build --platform linux/amd64 -f apps/api/Dockerfile -t forge-api .
 #
-# Local compose still uses context apps/api — see docker-compose.yml.
+# docker-compose.yml uses the same root context + this Dockerfile.
 
 FROM python:3.12-slim
 
@@ -22,7 +22,11 @@ COPY apps/api/runtime ./runtime
 COPY data/templates ./data/templates
 
 WORKDIR /app/runtime
-RUN npm ci --omit=dev
+# Preview iframe loads /runner/babel.min.js — vendor file is not committed
+# (~3MB). Copy from the already-pinned @babel/standalone install instead.
+RUN npm ci --omit=dev \
+  && cp node_modules/@babel/standalone/babel.min.js public/babel.min.js \
+  && test -s public/babel.min.js
 WORKDIR /app
 
 ENV PYTHONUNBUFFERED=1 \

--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -7,4 +7,4 @@
 -r requirements.txt
 
 ruff==0.16.4
-pytest==8.3.4
+pytest==9.1.1

--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -7,8 +7,4 @@
 -r requirements.txt
 
 ruff==0.16.4
-<<<<<<< HEAD
 pytest==9.1.1
-=======
-pytest==9.0.3
->>>>>>> origin/main

--- a/apps/api/runtime/package.json
+++ b/apps/api/runtime/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "postinstall": "node scripts/ensure-babel-standalone.mjs",
     "test": "node --test tests/*.test.mjs",
     "transform": "node cli.mjs"
   },

--- a/apps/api/runtime/scripts/ensure-babel-standalone.mjs
+++ b/apps/api/runtime/scripts/ensure-babel-standalone.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Keep runtime/public/babel.min.js in sync with @babel/standalone.
+ * The preview iframe loads /runner/babel.min.js; the vendor blob is not
+ * committed, so local compose (volume-mounted public/) and Docker builds
+ * both need this copy step.
+ */
+import { copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const src = join(root, "node_modules", "@babel", "standalone", "babel.min.js");
+const destDir = join(root, "public");
+const dest = join(destDir, "babel.min.js");
+
+if (!existsSync(src)) {
+  console.error(`[forge-runtime] missing ${src} — run npm ci in apps/api/runtime`);
+  process.exit(1);
+}
+
+mkdirSync(destDir, { recursive: true });
+copyFileSync(src, dest);
+const size = statSync(dest).size;
+if (size < 100_000) {
+  console.error(`[forge-runtime] babel.min.js looks too small (${size} bytes)`);
+  process.exit(1);
+}
+console.log(`[forge-runtime] wrote public/babel.min.js (${size} bytes)`);


### PR DESCRIPTION
## Summary
- En prod, `/runner/babel.min.js` renvoyait **404** → toutes les previews affichaient `src/main.tsx — Babel is not defined`.
- Cause : le vendor (~3 Mo) n’était pas committé et n’était pas généré dans l’image Docker.
- Fix : copie depuis `@babel/standalone` pendant `npm ci` dans le Dockerfile + `postinstall` local.

## Test plan
- [ ] CI Deploy API verte
- [ ] `GET https://forge.rodiumai.io/runner/babel.min.js` → 200
- [ ] Ouvrir un projet → preview sans erreur Babel
