### PR TITLE
Release: dep patches, preview fix, outbound URL validation

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -97,6 +97,12 @@ class Settings(BaseSettings):
     # Parent origins allowed to talk to the preview runner (comma-separated)
     runner_parent_origins: str = "http://localhost:3100,http://127.0.0.1:3100"
 
+    # Outbound URL guard (app/services/net_guard.py): when False (default),
+    # fetches of user-supplied URLs (website capture, image markers) refuse any
+    # host resolving to a private/loopback/link-local/reserved address or a
+    # cloud-metadata endpoint. Set True only for local dev/tests reaching 127.0.0.1.
+    url_fetch_allow_private: bool = False
+
     # Object store (MinIO local / S3 or R2 in production)
     object_store_provider: Literal["s3_compatible"] = "s3_compatible"
     object_store_endpoint: str | None = "http://127.0.0.1:9000"

--- a/apps/api/app/services/attachments.py
+++ b/apps/api/app/services/attachments.py
@@ -22,6 +22,7 @@ from app.services.asset_storage import (
     repair_private_upload_urls_in_project,
 )
 from app.services.filesystem import project_dir
+from app.services.net_guard import BlockedURLError, validate_public_url_async
 
 _IMAGE_MARKER_RE = re.compile(
     r"\[(?:Reference screenshot|Capture de référence|Image attached|Image jointe|"
@@ -197,18 +198,36 @@ def _read_local_public(project_id: str, web_path: str) -> tuple[bytes, str] | No
     return body, ctype
 
 
+_MAX_FETCH_REDIRECTS = 5
+
+
 async def _fetch_url(url: str) -> tuple[bytes, str] | None:
+    # Validate every hop ourselves instead of letting httpx follow redirects
+    # blindly — a public URL can 3xx to an internal host.
     try:
-        async with httpx.AsyncClient(timeout=20.0, follow_redirects=True) as client:
-            resp = await client.get(url)
-        if resp.status_code >= 400:
+        async with httpx.AsyncClient(timeout=20.0, follow_redirects=False) as client:
+            current = url
+            for _ in range(_MAX_FETCH_REDIRECTS + 1):
+                await validate_public_url_async(current)
+                resp = await client.get(current)
+                if resp.is_redirect:
+                    location = resp.headers.get("location")
+                    if not location:
+                        return None
+                    current = str(httpx.URL(str(resp.url)).join(location))
+                    continue
+                if resp.status_code >= 400:
+                    return None
+                body = resp.content
+                if len(body) > MAX_IMAGE_BYTES:
+                    # A truncated binary is a corrupt image; skip vision rather than send garbage.
+                    return None
+                ctype = (resp.headers.get("content-type") or "image/png").split(";")[0].strip()
+                return body, ctype
+            # Too many redirects.
             return None
-        body = resp.content
-        if len(body) > MAX_IMAGE_BYTES:
-            # A truncated binary is a corrupt image; skip vision rather than send garbage.
-            return None
-        ctype = (resp.headers.get("content-type") or "image/png").split(";")[0].strip()
-        return body, ctype
+    except BlockedURLError:
+        return None
     except Exception:
         return None
 

--- a/apps/api/app/services/net_guard.py
+++ b/apps/api/app/services/net_guard.py
@@ -25,8 +25,8 @@ _METADATA_IPS = frozenset(
     {
         "169.254.169.254",  # AWS / GCP / Azure IMDS
         "100.100.100.200",  # Alibaba Cloud
-        "192.0.0.192",      # Oracle Cloud
-        "fd00:ec2::254",    # AWS IMDS over IPv6
+        "192.0.0.192",  # Oracle Cloud
+        "fd00:ec2::254",  # AWS IMDS over IPv6
     }
 )
 

--- a/apps/api/app/services/net_guard.py
+++ b/apps/api/app/services/net_guard.py
@@ -1,0 +1,136 @@
+"""Outbound URL guard: only fetch user-supplied URLs whose resolved address is a
+public host, refusing private / loopback / link-local / reserved / cloud-metadata
+targets.
+
+Used by every path that fetches a URL the user controls (website screenshot
+capture, image markers). Validation happens *after* DNS resolution, and is
+repeated on every redirect/hop, so a public hostname that later resolves or
+redirects to an internal address is refused too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+from app.config import get_settings
+from app.services.llm import RodiumError
+
+# Cloud-metadata endpoints (defence in depth on top of the range checks below,
+# which already cover 169.254.0.0/16 as link-local). Kept explicit so the intent
+# is obvious and so oddballs outside the ranges are still caught.
+_METADATA_IPS = frozenset(
+    {
+        "169.254.169.254",  # AWS / GCP / Azure IMDS
+        "100.100.100.200",  # Alibaba Cloud
+        "192.0.0.192",      # Oracle Cloud
+        "fd00:ec2::254",    # AWS IMDS over IPv6
+    }
+)
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+class BlockedURLError(RodiumError):
+    """A user-supplied URL was refused by the outbound URL guard."""
+
+    def __init__(self, message: str = "This URL is not allowed."):
+        super().__init__(message, None, "blocked_url")
+
+
+def _ip_is_blocked(ip: ipaddress._BaseAddress) -> bool:
+    """True if `ip` points at a non-public / metadata destination."""
+    # Normalise IPv4-mapped IPv6 (::ffff:a.b.c.d) to the underlying IPv4 so a
+    # mapped private/metadata address can't slip through the v6 checks.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+
+    if str(ip) in _METADATA_IPS:
+        return True
+
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
+        return True
+
+    # IPv6 site-local (fec0::/10, deprecated) is covered by is_reserved on some
+    # Python versions but not all; check explicitly.
+    return bool(isinstance(ip, ipaddress.IPv6Address) and ip.is_site_local)
+
+
+def _resolve_ips(host: str, port: int) -> list[str]:
+    """All IPs `host` resolves to. Raises on failure (caller fails closed)."""
+    infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    return [info[4][0] for info in infos]
+
+
+def validate_public_url(url: str) -> None:
+    """Raise BlockedURLError unless `url` is a public http(s) destination.
+
+    Rejects: non-http(s) schemes, missing host, embedded credentials (userinfo),
+    and any host that resolves (or literally is) a private/loopback/link-local/
+    reserved/multicast/unspecified IP or a known cloud-metadata endpoint.
+
+    Fails closed: DNS resolution failure is treated as blocked.
+    """
+    settings = None
+    try:
+        settings = get_settings()
+    except Exception:  # pragma: no cover - config must load, but never open up on error
+        settings = None
+    if settings is not None and getattr(settings, "url_fetch_allow_private", False):
+        return
+
+    parsed = urlparse(url or "")
+
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise BlockedURLError("Only http(s) URLs are allowed.")
+
+    if parsed.username or parsed.password:
+        raise BlockedURLError("URLs with embedded credentials are not allowed.")
+
+    host = parsed.hostname
+    if not host:
+        raise BlockedURLError("URL has no host.")
+
+    port = parsed.port or (443 if parsed.scheme.lower() == "https" else 80)
+
+    # A literal IP in the URL is validated directly (getaddrinfo would echo it
+    # back, but this avoids relying on resolver behaviour for literals).
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        if _ip_is_blocked(literal):
+            raise BlockedURLError()
+        return
+
+    try:
+        resolved = _resolve_ips(host, port)
+    except Exception as exc:
+        raise BlockedURLError("Could not resolve host.") from exc
+
+    if not resolved:
+        raise BlockedURLError("Could not resolve host.")
+
+    for raw in resolved:
+        try:
+            ip = ipaddress.ip_address(raw)
+        except ValueError:
+            # An address the stdlib can't parse is not something we'll trust.
+            raise BlockedURLError() from None
+        if _ip_is_blocked(ip):
+            raise BlockedURLError()
+
+
+async def validate_public_url_async(url: str) -> None:
+    """Async wrapper — getaddrinfo is blocking, so run it off the event loop."""
+    await asyncio.to_thread(validate_public_url, url)

--- a/apps/api/app/services/url_capture.py
+++ b/apps/api/app/services/url_capture.py
@@ -10,6 +10,11 @@ from urllib.parse import urlparse
 from app.services.attachments import count_markers_by_intent
 from app.services.filesystem import write_bytes
 from app.services.llm import RodiumError
+from app.services.net_guard import (
+    BlockedURLError,
+    validate_public_url,
+    validate_public_url_async,
+)
 
 logger = logging.getLogger("url_capture")
 
@@ -73,12 +78,25 @@ def _capture_sync(url: str) -> list[tuple[str, bytes]]:
             "upstream",
         ) from exc
 
+    def _guard_route(route) -> None:
+        # Re-validate every request (initial navigation, redirects, subresources)
+        # so a redirect to an internal host is aborted mid-flight.
+        try:
+            validate_public_url(route.request.url)
+        except BlockedURLError:
+            with contextlib.suppress(Exception):
+                route.abort()
+            return
+        with contextlib.suppress(Exception):
+            route.continue_()
+
     shots: list[tuple[str, bytes]] = []
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
         try:
             for label, width, height in _VIEWPORTS:
                 page = browser.new_page(viewport={"width": width, "height": height})
+                page.route("**/*", _guard_route)
                 try:
                     page.goto(url, wait_until="domcontentloaded", timeout=_NAV_TIMEOUT_MS)
                     with contextlib.suppress(Exception):
@@ -105,6 +123,18 @@ async def capture_site_screenshots(
 ) -> list[dict[str, str]]:
     """Write desktop+mobile PNGs under public/images/; return marker metadata."""
     import asyncio
+
+    try:
+        await validate_public_url_async(url)
+    except BlockedURLError as exc:
+        # Don't leak *why* (internal host, metadata, etc.) — same message as an
+        # unreachable public site.
+        msg = (
+            f"Impossible de capturer {url}. Vérifie que le site est public et réessaie."
+            if locale == "fr"
+            else f"Could not capture {url}. Check the site is public and try again."
+        )
+        raise RodiumError(msg, None, "upstream") from exc
 
     try:
         shots = await asyncio.to_thread(_capture_sync, url)

--- a/apps/api/tests/test_net_guard.py
+++ b/apps/api/tests/test_net_guard.py
@@ -1,0 +1,131 @@
+"""Outbound URL guard: user-supplied URLs must not reach private / metadata targets.
+
+DNS is monkeypatched so tests are hermetic (no real resolution) and so we can
+model a public hostname that resolves to an internal IP.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import httpx
+import pytest
+
+from app.config import clear_settings_cache
+from app.services import attachments
+from app.services.net_guard import BlockedURLError, validate_public_url
+
+
+def _fake_getaddrinfo(ip: str):
+    """Return a getaddrinfo stub that resolves every host to `ip`."""
+
+    def _resolver(host, port, *args, **kwargs):
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        sockaddr = (ip, port, 0, 0) if family == socket.AF_INET6 else (ip, port)
+        return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)]
+
+    return _resolver
+
+
+@pytest.fixture(autouse=True)
+def _guard_enabled(monkeypatch):
+    # Guard is default-on; make sure no env leaves it disabled during tests.
+    monkeypatch.setenv("URL_FETCH_ALLOW_PRIVATE", "false")
+    clear_settings_cache()
+    yield
+    clear_settings_cache()
+
+
+BLOCKED_LITERALS = [
+    "http://127.0.0.1/",
+    "http://[::1]/",
+    "http://10.0.0.5/",
+    "http://172.16.0.1/",
+    "http://192.168.1.1/",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://[::ffff:169.254.169.254]/",
+    "http://0.0.0.0/",
+    "http://100.100.100.200/",
+]
+
+
+@pytest.mark.parametrize("url", BLOCKED_LITERALS)
+def test_blocks_private_and_metadata_literals(url):
+    with pytest.raises(BlockedURLError):
+        validate_public_url(url)
+
+
+def test_blocks_non_http_schemes():
+    for url in ("file:///etc/passwd", "gopher://x/", "ftp://host/x"):
+        with pytest.raises(BlockedURLError):
+            validate_public_url(url)
+
+
+def test_blocks_userinfo():
+    with pytest.raises(BlockedURLError):
+        validate_public_url("http://user:pass@example.com/")
+
+
+def test_blocks_missing_host():
+    with pytest.raises(BlockedURLError):
+        validate_public_url("http:///path")
+
+
+def test_blocks_public_host_resolving_to_private(monkeypatch):
+    # Public-looking hostname that resolves to an internal IP.
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("10.1.2.3"))
+    with pytest.raises(BlockedURLError):
+        validate_public_url("http://totally-legit.example.com/")
+
+
+def test_blocks_when_resolution_fails(monkeypatch):
+    def _boom(*args, **kwargs):
+        raise socket.gaierror("nope")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _boom)
+    with pytest.raises(BlockedURLError):
+        validate_public_url("http://example.com/")
+
+
+def test_allows_public_host(monkeypatch):
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+    # Should not raise.
+    validate_public_url("https://example.com/page")
+
+
+def test_allow_private_setting_bypasses(monkeypatch):
+    monkeypatch.setenv("URL_FETCH_ALLOW_PRIVATE", "true")
+    clear_settings_cache()
+    try:
+        validate_public_url("http://127.0.0.1:8000/")  # should not raise
+    finally:
+        clear_settings_cache()
+
+
+# --- sink: attachments._fetch_url --------------------------------------------
+
+
+def test_fetch_url_refuses_private(monkeypatch):
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("10.0.0.9"))
+
+    async def _no_get(self, url, **kwargs):  # pragma: no cover - must never run
+        raise AssertionError("network was reached for a blocked URL")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _no_get)
+    assert asyncio.run(attachments._fetch_url("http://internal.example.com/img.png")) is None
+
+
+def test_fetch_url_refuses_redirect_to_metadata(monkeypatch):
+    # Initial host is public; it 302s to the metadata IP, which must be refused.
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+
+    async def fake_get(self, url, **kwargs):
+        return httpx.Response(
+            status_code=302,
+            headers={"location": "http://169.254.169.254/latest/meta-data/"},
+            request=httpx.Request("GET", str(url)),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    assert asyncio.run(attachments._fetch_url("http://example.com/img.png")) is None


### PR DESCRIPTION
Promote `dev` to `main`.

Included changes:
- Dependency patches (dompurify, postcss, pytest) from Dependabot
- Ship `babel.min.js` in the API image (preview runner)
- CI: drop leftover merge-conflict markers in requirements-dev
- Validate outbound URL targets before server-side fetch (capture + image markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)