### PR TITLE
fix(ci): unblock deploy after dashboard UI

### DIFF
--- a/apps/api/app/routers/projects.py
+++ b/apps/api/app/routers/projects.py
@@ -28,12 +28,12 @@ from app.services import preview_babel
 from app.services.filesystem import list_files, project_dir, write_bytes
 from app.services.posthog_client import capture_for_user
 from app.services.project_delete import delete_project_full
+from app.services.project_naming import suggest_project_name
 from app.services.scaffold import (
     brand_placeholder_html,
     is_text_brand_placeholder,
+    scaffold_vite_react,
 )
-from app.services.project_naming import suggest_project_name
-from app.services.scaffold import scaffold_vite_react
 from app.services.templates import fork_template, get_template, preview_path
 
 logger = logging.getLogger("projects")

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -656,7 +656,6 @@ function DashboardInner() {
                     <div className="home-card-body">
                       <span className="home-card-avatar" aria-hidden>
                         {avatarUrl ? (
-                          // eslint-disable-next-line @next/next/no-img-element -- session avatar URL, may be data/http
                           <img src={avatarUrl} alt="" />
                         ) : (
                           <span>{projectInitials(ownerLabel)}</span>

--- a/apps/web/components/SiteThumb.tsx
+++ b/apps/web/components/SiteThumb.tsx
@@ -539,7 +539,6 @@ export function SiteThumb({
       }}
     >
       {usePersistedImage ? (
-        // eslint-disable-next-line @next/next/no-img-element -- authenticated API JPEG
         <img
           className="site-thumb-snap"
           src={imageSrc!}
@@ -550,7 +549,6 @@ export function SiteThumb({
       ) : frameSrc ? (
         <>
           {snapshot ? (
-            // eslint-disable-next-line @next/next/no-img-element -- data-URL snapshot, not a remote asset
             <img className="site-thumb-snap" src={snapshot} alt="" draggable={false} />
           ) : capped ? (
             // Budget spent — static branded placeholder, no pulse (final state).


### PR DESCRIPTION
Fix ruff I001 on projects.py and trim unused eslint-disable warnings so CI stays under max-warnings=10.

Made with [Cursor](https://cursor.com)