### PR TITLE
fix(dashboard): cartes modeles avec preview

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -579,29 +579,39 @@ function DashboardInner() {
         ) : showTemplates ? (
           <>
             <div className="home-grid home-grid-3">
-              {filteredTemplates.map((tpl) => (
-                <button
-                  key={tpl.id}
-                  type="button"
-                  className="home-card"
-                  disabled={Boolean(forkingId) || creating}
-                  onClick={() => void forkTemplate(tpl)}
-                >
-                  <SiteThumb
-                    src={tpl.preview_url || `/templates/${tpl.id}/preview`}
-                    viewportWidth={480}
-                    viewportHeight={300}
-                    title={tpl.title}
-                    className="home-card-thumb"
-                  />
-                  <div className="home-card-body">
-                    <strong>{tpl.title}</strong>
-                    <span>
-                      {forkingId === tpl.id ? t("forkingTemplate") : tpl.description}
-                    </span>
-                  </div>
-                </button>
-              ))}
+              {filteredTemplates.map((tpl) => {
+                const tag = tpl.tags?.[0]?.trim() || t("tabTemplates");
+                return (
+                  <button
+                    key={tpl.id}
+                    type="button"
+                    className="home-card"
+                    disabled={Boolean(forkingId) || creating}
+                    onClick={() => void forkTemplate(tpl)}
+                  >
+                    <div className="home-card-media">
+                      <SiteThumb
+                        src={tpl.preview_url || `/templates/${tpl.id}/preview`}
+                        viewportWidth={480}
+                        viewportHeight={300}
+                        title={tpl.title}
+                        className="home-card-thumb"
+                      />
+                    </div>
+                    <div className="home-card-body">
+                      <span className="home-card-avatar" aria-hidden>
+                        <span>{projectInitials(tpl.title)}</span>
+                      </span>
+                      <div className="home-card-meta">
+                        <strong title={tpl.title}>{tpl.title}</strong>
+                        <span className="home-card-desc" title={tpl.description}>
+                          {forkingId === tpl.id ? t("forkingTemplate") : tpl.description || tag}
+                        </span>
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
             </div>
             {filteredTemplates.length === 0 && (
               <p className="home-panel-empty">{t("noTemplates")}</p>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7709,6 +7709,16 @@ body:has(.home) [data-next-mark] {
   text-overflow: ellipsis;
 }
 
+.home-card-meta .home-card-desc {
+  white-space: normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Scaled homepage thumbnails (srcDoc + ResizeObserver scale) */
 .site-thumb {
   position: relative;
@@ -7905,7 +7915,14 @@ body:has(.home) [data-next-mark] {
   gap: 0.9rem;
 }
 
-.tpl-card {
+.home-card.tpl-card {
+  border: none;
+  background: transparent;
+  overflow: visible;
+  border-radius: 18px;
+}
+
+.tpl-card:not(.home-card) {
   appearance: none;
   display: flex;
   flex-direction: column;

--- a/apps/web/components/TemplateGallery.tsx
+++ b/apps/web/components/TemplateGallery.tsx
@@ -92,22 +92,38 @@ export function TemplateGallery({
           <button
             key={tpl.id}
             type="button"
-            className="tpl-card"
+            className="home-card tpl-card"
             disabled={Boolean(busyId)}
             onClick={() => onSelect(tpl)}
           >
-            <SiteThumb
-              src={tpl.preview_url || `/templates/${tpl.id}/preview`}
-              viewportWidth={480}
-              viewportHeight={300}
-              title={tpl.title}
-              className="tpl-card-thumb"
-            />
-            <div className="tpl-card-meta">
-              <strong>{tpl.title}</strong>
-              <span>
-                {busyId === tpl.id ? t("forkingTemplate") : tpl.description}
+            <div className="home-card-media">
+              <SiteThumb
+                src={tpl.preview_url || `/templates/${tpl.id}/preview`}
+                viewportWidth={480}
+                viewportHeight={300}
+                title={tpl.title}
+                className="home-card-thumb tpl-card-thumb"
+              />
+            </div>
+            <div className="home-card-body">
+              <span className="home-card-avatar" aria-hidden>
+                <span>
+                  {tpl.title
+                    .trim()
+                    .split(/\s+/)
+                    .filter(Boolean)
+                    .slice(0, 2)
+                    .map((w) => w[0] || "")
+                    .join("")
+                    .toUpperCase() || "T"}
+                </span>
               </span>
+              <div className="home-card-meta">
+                <strong title={tpl.title}>{tpl.title}</strong>
+                <span className="home-card-desc" title={tpl.description}>
+                  {busyId === tpl.id ? t("forkingTemplate") : tpl.description}
+                </span>
+              </div>
             </div>
           </button>
         ))}


### PR DESCRIPTION
## Summary
- Cartes modeles alignees sur le style projets (preview, avatar, titre, description)
- Correction du flex horizontal qui tronquait les titres (Astr...)
- TemplateGallery landing/home mis a jour pareil

## Test plan
- [ ] Dashboard onglet Modeles : thumbs + titres lisibles
- [ ] Cliquer un modele fork correctement
- [ ] Landing gallery si presente : meme layout