### PR TITLE
fix(api): firebase-admin manquant — login Google 500

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -3,9 +3,9 @@ import contextlib
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.config import get_settings
@@ -73,6 +73,38 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def _cors_origin_allowed(origin: str | None) -> bool:
+    if not origin:
+        return False
+    if origin in config.cors_origin_list:
+        return True
+    regex = config.cors_origin_regex
+    if not regex:
+        return False
+    import re
+
+    return re.fullmatch(regex, origin) is not None
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Ensure browsers still see CORS headers on unexpected 500s.
+
+    Starlette's ServerErrorMiddleware sits outside CORSMiddleware, so an
+    unhandled crash otherwise looks like a CORS failure in DevTools
+    (`No Access-Control-Allow-Origin`) and hides the real 500.
+    """
+    logger.exception("unhandled error on %s %s", request.method, request.url.path)
+    response = JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
+    origin = request.headers.get("origin")
+    if _cors_origin_allowed(origin):
+        response.headers["Access-Control-Allow-Origin"] = origin or ""
+        response.headers["Access-Control-Allow-Credentials"] = "true"
+        response.headers["Vary"] = "Origin"
+    return response
+
 
 app.include_router(auth.router)
 app.include_router(settings_router.router)

--- a/apps/api/app/services/firebase_auth.py
+++ b/apps/api/app/services/firebase_auth.py
@@ -53,21 +53,33 @@ def _get_app():
         settings = get_settings()
         if not settings.firebase_enabled:
             raise FirebaseAuthError("firebase_not_configured")
-        import firebase_admin
-        from firebase_admin import credentials
+        try:
+            import firebase_admin
+            from firebase_admin import credentials
+        except ImportError as exc:
+            # Misbuilt image (dep missing from requirements) must not 500 the
+            # login route — surface the same "not configured" path as empty env.
+            logger.error("firebase_admin package is not installed")
+            raise FirebaseAuthError("firebase_not_configured") from exc
 
-        cred = credentials.Certificate(
-            {
-                "type": "service_account",
-                "project_id": settings.firebase_project_id,
-                "client_email": settings.firebase_client_email,
-                "private_key": settings.firebase_private_key_pem,
-                "token_uri": "https://oauth2.googleapis.com/token",
-            }
-        )
-        # Named so we never collide with an app another part of the process
-        # may have initialised.
-        _app = firebase_admin.initialize_app(cred, name="forge-auth")
+        try:
+            cred = credentials.Certificate(
+                {
+                    "type": "service_account",
+                    "project_id": settings.firebase_project_id,
+                    "client_email": settings.firebase_client_email,
+                    "private_key": settings.firebase_private_key_pem,
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                }
+            )
+            # Named so we never collide with an app another part of the process
+            # may have initialised.
+            _app = firebase_admin.initialize_app(cred, name="forge-auth")
+        except FirebaseAuthError:
+            raise
+        except Exception as exc:
+            logger.exception("firebase admin SDK failed to initialise")
+            raise FirebaseAuthError("firebase_not_configured") from exc
         return _app
 
 
@@ -81,11 +93,13 @@ def _map_provider(raw: str | None) -> str:
 
 def verify_id_token(id_token: str) -> FederatedIdentity:
     """Verify and unpack an ID token, or raise `FirebaseAuthError`."""
-    app = _get_app()
-    from firebase_admin import auth as fb_auth
-
     try:
+        app = _get_app()
+        from firebase_admin import auth as fb_auth
+
         claims = fb_auth.verify_id_token(id_token, app=app)
+    except FirebaseAuthError:
+        raise
     except Exception as exc:
         raise FirebaseAuthError("invalid_id_token") from exc
 

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,4 +1,4 @@
-﻿fastapi>=0.115.0,<0.116
+fastapi>=0.115.0,<0.116
 uvicorn[standard]>=0.34.0,<0.35
 sqlalchemy>=2.0.40,<2.1
 psycopg[binary]>=3.2.10,<4
@@ -21,3 +21,4 @@ tree-sitter>=0.23.0,<0.25
 tree-sitter-typescript>=0.23.0,<0.24
 tree-sitter-javascript>=0.23.0,<0.24
 playwright>=1.49.0,<2
+firebase-admin>=6.5.0,<7

--- a/apps/api/tests/test_auth_linking.py
+++ b/apps/api/tests/test_auth_linking.py
@@ -327,6 +327,32 @@ class TestFirebaseIdentityMapping:
         with pytest.raises(firebase_auth.FirebaseAuthError):
             firebase_auth._map_provider(None)
 
+    def test_missing_firebase_admin_package_reports_not_configured(self, monkeypatch):
+        """Prod image once shipped without the dep — must be 503, never 500."""
+        firebase_auth._app = None
+
+        class _Settings:
+            firebase_enabled = True
+            firebase_project_id = "rodiumai"
+            firebase_client_email = "sa@rodiumai.iam.gserviceaccount.com"
+            firebase_private_key_pem = "-----BEGIN PRIVATE KEY-----\nX\n-----END PRIVATE KEY-----\n"
+
+        monkeypatch.setattr(firebase_auth, "get_settings", lambda: _Settings())
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _blocked(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+            if name == "firebase_admin" or name.startswith("firebase_admin."):
+                raise ImportError("firebase_admin missing")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _blocked)
+
+        with pytest.raises(firebase_auth.FirebaseAuthError, match="firebase_not_configured"):
+            firebase_auth._get_app()
+
 
 class TestVerificationGate:
     """No confirmed address, no session — on every path that issues one.


### PR DESCRIPTION
## Summary
- Cause prod: `ModuleNotFoundError: firebase_admin` sur `POST /auth/oauth/firebase` (dépendance absente de `requirements.txt` / image ECS).
- Ajoute `firebase-admin` et mappe ImportError / échec d'init vers 503 `firebase_not_configured`.
- Handler d'exception CORS pour que les vrais 500 restent lisibles dans le navigateur (plus de faux positif CORS).

## Test plan
- [ ] CI API verte
- [ ] Après deploy ECS: `POST /auth/oauth/firebase` avec token invalide → 401/503 JSON (plus de 500 texte brut)
- [ ] Login Google sur https://forge.rodiumai.io/login aboutit (session Forge)
- [ ] Les warnings COOP `window.closed` Firebase restent du bruit non bloquant

Made with [Cursor](https://cursor.com)