### PR TITLE
Harden config validation, path handling and auth guards

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -328,27 +328,40 @@ def _is_placeholder_secret(value: str | None) -> bool:
 @lru_cache
 def get_settings() -> Settings:
     s = Settings()
-    # Garde-fou anti pied de biche : interdire les providers de développement en production.
-    if s.environment == "production":
-        assert s.key_provider == "kms", "KEY_PROVIDER doit être kms en production"
-        assert s.secret_provider == "aws_secrets_manager", "SECRET_PROVIDER invalide en production"
-        assert s.dev_master_key is None, "DEV_MASTER_KEY doit être absente en production"
-        assert not s.object_store_endpoint or "minio" not in (s.object_store_endpoint or ""), (
-            "OBJECT_STORE_ENDPOINT MinIO interdit en production"
-        )
+    # Garde-fous exprimés en `raise` (pas `assert`) pour survivre à `python -O`.
+    #
+    # Hygiène des secrets sur toute cible exposée (non-locale) : un JWT de session
+    # forgeable ou une clé de chiffrement au repos faible est exploitable en
+    # staging comme en production, pas seulement en prod.
+    if not s.is_local:
         # Le JWT de session ne doit jamais être signé avec une clé de développement.
-        assert s.secret_key not in _DEV_SECRET_KEYS, "SECRET_KEY de développement interdite en production"
-        assert len(s.secret_key) >= 32, "SECRET_KEY doit faire au moins 32 caractères en production"
-        assert not _is_placeholder_secret(s.secret_key), (
-            "SECRET_KEY ressemble à un placeholder de .env.example — générez une vraie clé aléatoire"
-        )
-        # ENCRYPTION_KEY doit être distincte : sinon compromettre le JWT compromet
-        # aussi les clés API RodiumAi et les refresh tokens chiffrés au repos.
-        assert s.encryption_key, "ENCRYPTION_KEY est obligatoire en production"
-        assert s.encryption_key != s.secret_key, "ENCRYPTION_KEY doit différer de SECRET_KEY"
-        assert not _is_placeholder_secret(s.encryption_key), (
-            "ENCRYPTION_KEY ressemble à un placeholder — générez une vraie clé aléatoire"
-        )
+        if s.secret_key in _DEV_SECRET_KEYS:
+            raise RuntimeError("SECRET_KEY de développement interdite hors environnement local")
+        if len(s.secret_key) < 32:
+            raise RuntimeError("SECRET_KEY doit faire au moins 32 caractères hors local")
+        if _is_placeholder_secret(s.secret_key):
+            raise RuntimeError(
+                "SECRET_KEY ressemble à un placeholder de .env.example — générez une vraie clé aléatoire"
+            )
+        # ENCRYPTION_KEY doit être présente et distincte : sinon compromettre le JWT
+        # compromet aussi les clés API RodiumAi et les refresh tokens chiffrés au repos.
+        if not s.encryption_key:
+            raise RuntimeError("ENCRYPTION_KEY est obligatoire hors local")
+        if s.encryption_key == s.secret_key:
+            raise RuntimeError("ENCRYPTION_KEY doit différer de SECRET_KEY")
+        if _is_placeholder_secret(s.encryption_key):
+            raise RuntimeError("ENCRYPTION_KEY ressemble à un placeholder — générez une vraie clé aléatoire")
+
+    # Durcissement propre à l'infrastructure de production.
+    if s.environment == "production":
+        if s.key_provider != "kms":
+            raise RuntimeError("KEY_PROVIDER doit être kms en production")
+        if s.secret_provider != "aws_secrets_manager":
+            raise RuntimeError("SECRET_PROVIDER invalide en production")
+        if s.dev_master_key is not None:
+            raise RuntimeError("DEV_MASTER_KEY doit être absente en production")
+        if s.object_store_endpoint and "minio" in s.object_store_endpoint:
+            raise RuntimeError("OBJECT_STORE_ENDPOINT MinIO interdit en production")
     return s
 
 

--- a/apps/api/app/crypto.py
+++ b/apps/api/app/crypto.py
@@ -15,6 +15,11 @@ def _fernet() -> Fernet:
             return Fernet(key)
         except Exception:
             pass
+    # No valid explicit ENCRYPTION_KEY. Deriving one from SECRET_KEY is only
+    # acceptable locally; anywhere else the SECRET_KEY may be a public default,
+    # which would leave stored API keys / refresh tokens readable.
+    if not settings.is_local:
+        raise RuntimeError("ENCRYPTION_KEY is required (a valid Fernet key) outside local environments")
     digest = hashlib.sha256((raw or settings.secret_key).encode("utf-8")).digest()
     return Fernet(base64.urlsafe_b64encode(digest))
 

--- a/apps/api/app/routers/internal_admin.py
+++ b/apps/api/app/routers/internal_admin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
@@ -22,7 +23,7 @@ def _require_admin_secret(x_forge_admin_secret: str | None = Header(default=None
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={"code": "forge_admin_unconfigured", "message": "ADMIN_SECRET is not set."},
         )
-    if not x_forge_admin_secret or x_forge_admin_secret != expected:
+    if not x_forge_admin_secret or not hmac.compare_digest(x_forge_admin_secret, expected):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail={"code": "forge_admin_unauthorized", "message": "Invalid admin secret."},

--- a/apps/api/app/services/attachments.py
+++ b/apps/api/app/services/attachments.py
@@ -21,7 +21,7 @@ from app.services.asset_storage import (
     materialize_asset_to_public,
     repair_private_upload_urls_in_project,
 )
-from app.services.filesystem import project_dir
+from app.services.filesystem import project_dir, safe_resolve
 from app.services.net_guard import BlockedURLError, validate_public_url_async
 
 _IMAGE_MARKER_RE = re.compile(
@@ -177,10 +177,18 @@ def _read_local_public(project_id: str, web_path: str) -> tuple[bytes, str] | No
     rel = web_path.lstrip("/")
     if not rel:
         return None
-    disk = project_dir(project_id) / "public" / rel
-    if not disk.is_file():
-        disk = project_dir(project_id) / rel
-    if not disk.is_file():
+    # The marker path comes from user content; route every candidate through
+    # safe_resolve so a "../" cannot escape the project into an arbitrary file.
+    disk = None
+    for candidate in (f"public/{rel}", rel):
+        try:
+            resolved = safe_resolve(project_id, candidate)
+        except ValueError:
+            continue
+        if resolved.is_file():
+            disk = resolved
+            break
+    if disk is None:
         return None
     body = disk.read_bytes()
     if len(body) > MAX_IMAGE_BYTES:

--- a/apps/api/app/services/filesystem.py
+++ b/apps/api/app/services/filesystem.py
@@ -18,7 +18,9 @@ def project_dir(project_id: str) -> Path:
 def safe_resolve(project_id: str, relative: str) -> Path:
     base = project_dir(project_id).resolve()
     target = (base / relative).resolve()
-    if not str(target).startswith(str(base)):
+    # Containment on path components, not string prefix: a sibling dir whose name
+    # merely starts with the project id (e.g. "<id>extra") must not pass.
+    if target != base and base not in target.parents:
         raise ValueError("Path escapes project root")
     return target
 

--- a/apps/api/tests/test_auth_local.py
+++ b/apps/api/tests/test_auth_local.py
@@ -292,6 +292,9 @@ class TestMail:
 
         monkeypatch.setenv("MAIL_TRANSPORT", "smtp")
         monkeypatch.setenv("ENVIRONMENT", "staging")
+        # A non-local environment requires real secrets to boot.
+        monkeypatch.setenv("SECRET_KEY", "s3cret-key-for-staging-tests-0123456789")
+        monkeypatch.setenv("ENCRYPTION_KEY", "enc-key-for-staging-tests-9876543210abcd")
         clear_settings_cache()
         monkeypatch.setattr(mail, "_send_smtp", MagicMock(side_effect=OSError("no host")))
         console = MagicMock()

--- a/apps/api/tests/test_filesystem.py
+++ b/apps/api/tests/test_filesystem.py
@@ -134,6 +134,36 @@ class TestPublicAssets:
         assert target.relative_to(root)
 
 
+class TestReadLocalPublic:
+    """Image markers can carry a `public:` path that we read off disk.
+
+    The path comes from user content, so a `../` must never let it read a file
+    outside the project (build secrets, other tenants, /etc/passwd).
+    """
+
+    def test_reads_a_public_asset(self, project):
+        from app.services.attachments import _read_local_public
+
+        write_bytes(project, "public/logo.png", b"\x89PNG\r\n\x1a\n")
+        result = _read_local_public(project, "/logo.png")
+        assert result is not None
+        body, ctype = result
+        assert body.startswith(b"\x89PNG")
+        assert ctype == "image/png"
+
+    @pytest.mark.parametrize(
+        "web_path",
+        ["/../../../etc/passwd", "../secret.env", "/public/../../escape.txt"],
+    )
+    def test_refuses_paths_escaping_the_project(self, project, web_path):
+        from app.services.attachments import _read_local_public
+
+        # A real file just outside the project root — a naive join would reach it.
+        outside = project_dir(project).parent / "escape.txt"
+        outside.write_bytes(b"\x89PNG top secret")
+        assert _read_local_public(project, web_path) is None
+
+
 class TestRename:
     def test_renames_a_file(self, project):
         write_file(project, "src/Old.tsx", "x")

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -23,6 +23,7 @@ import { PasswordField } from "@/components/auth/PasswordField";
 import { SocialButtons } from "@/components/auth/SocialButtons";
 import { ApiError, api, getToken, setToken } from "@/lib/api";
 import { createStateBinding } from "@/lib/oauth-state";
+import { sanitizeReturnTo } from "@/lib/rodium-oauth";
 import { firebaseEnabled } from "@/lib/firebase";
 import { useI18n } from "@/lib/i18n/I18nProvider";
 
@@ -53,7 +54,7 @@ function LoginInner() {
   const startedRef = useRef(false);
 
   function land() {
-    window.location.assign(params.get("next") || "/dashboard");
+    window.location.assign(sanitizeReturnTo(params.get("next")) || "/dashboard");
   }
 
   async function loginWithRodium() {

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -23,6 +23,7 @@ import { PasswordField } from "@/components/auth/PasswordField";
 import { SocialButtons } from "@/components/auth/SocialButtons";
 import { api, getToken } from "@/lib/api";
 import { firebaseEnabled } from "@/lib/firebase";
+import { sanitizeReturnTo } from "@/lib/rodium-oauth";
 import { useI18n } from "@/lib/i18n/I18nProvider";
 
 type RegistrationResponse = { email: string; message?: string | null };
@@ -47,7 +48,7 @@ function RegisterInner() {
   function land() {
     // Hard navigation: the landing page stashed a pending prompt in
     // sessionStorage and the dashboard replays it on mount.
-    window.location.assign(params.get("next") || "/dashboard");
+    window.location.assign(sanitizeReturnTo(params.get("next")) || "/dashboard");
   }
 
   async function submit(event: React.FormEvent) {

--- a/apps/web/lib/rodium-oauth.test.ts
+++ b/apps/web/lib/rodium-oauth.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The open-redirect guard behind post-auth landing.
+ *
+ * `land()` on login/register and the OAuth return-to both feed a caller-supplied
+ * `next` into `window.location.assign`. Anything that is not a same-origin path
+ * must be dropped, or `?next=https://evil.example` turns the trusted auth page
+ * into a redirector.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sanitizeReturnTo } from "@/lib/rodium-oauth";
+
+describe("sanitizeReturnTo", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", { location: { origin: "https://forge.rodiumai.io" } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps a relative same-origin path", () => {
+    expect(sanitizeReturnTo("/dashboard?tab=x#y")).toBe("/dashboard?tab=x#y");
+  });
+
+  it("keeps an absolute same-origin URL as a path", () => {
+    expect(sanitizeReturnTo("https://forge.rodiumai.io/settings?tab=generation")).toBe(
+      "/settings?tab=generation",
+    );
+  });
+
+  it.each([
+    "https://evil.example/phish",
+    "//evil.example",
+    "http://forge.rodiumai.io.evil.example/",
+    "javascript:alert(1)",
+    "  ",
+    "",
+    null,
+    undefined,
+  ])("rejects %p", (value) => {
+    expect(sanitizeReturnTo(value)).toBeNull();
+  });
+});

--- a/apps/web/lib/rodium-oauth.ts
+++ b/apps/web/lib/rodium-oauth.ts
@@ -12,7 +12,7 @@ import { createStateBinding } from "@/lib/oauth-state";
 const RETURN_TO_KEY = "forge_oauth_return_to";
 
 /** Only allow same-origin paths (open-redirect guard). */
-function sanitizeReturnTo(value: string | undefined | null): string | null {
+export function sanitizeReturnTo(value: string | undefined | null): string | null {
   if (!value) return null;
   const trimmed = value.trim();
   // Preferred form: relative path.


### PR DESCRIPTION
Batch of defensive hardening across API and web, shipped as a normal correction.

## API
- **config**: replace `assert`-based startup guards with explicit `RuntimeError` checks so they survive `python -O`. Adds secret-hygiene checks (no dev/placeholder `SECRET_KEY`, min length, required distinct `ENCRYPTION_KEY`) on any non-local environment, plus the existing production infra invariants.
- **crypto**: require a real `ENCRYPTION_KEY` outside local environments instead of silently deriving one from `SECRET_KEY`.
- **filesystem**: `safe_resolve` now checks containment on path components rather than a string prefix (a sibling dir whose name merely starts with the project id no longer passes).
- **attachments**: local public asset reads go through `safe_resolve` so a marker path cannot escape the project root.
- **internal admin**: constant-time comparison for the admin secret header.

## Web
- Reuse `sanitizeReturnTo` for the post-auth landing on login/register so `?next=` only accepts same-origin paths.

## Tests
- Path-containment cases for `_read_local_public`, `sanitizeReturnTo` unit test, and staging secret setup for the mail fallback test.
- API suite: 390 passed. Web: typecheck + lint clean, new test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)