### PR TITLE
fix(api): ruff RUF100 unused noqa

### DIFF
--- a/apps/api/tests/test_auth_linking.py
+++ b/apps/api/tests/test_auth_linking.py
@@ -343,7 +343,7 @@ class TestFirebaseIdentityMapping:
 
         real_import = builtins.__import__
 
-        def _blocked(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+        def _blocked(name, globals=None, locals=None, fromlist=(), level=0):
             if name == "firebase_admin" or name.startswith("firebase_admin."):
                 raise ImportError("firebase_admin missing")
             return real_import(name, globals, locals, fromlist, level)


### PR DESCRIPTION
Unblocks CI after #69 — remove unused `# noqa: A002`.

Made with [Cursor](https://cursor.com)