### PR TITLE
fix(auth): sticky compte RodiumAi + wallet après recharge

### DIFF
--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -222,16 +222,20 @@ def rodium_oauth_start(request: Request) -> OAuthStartResponse:
     `state_binding` is a one-time secret the browser generated and kept in
     `sessionStorage`; only its hash reaches us. The callback must present the
     original, which is what ties the flow to the browser that started it.
+
+    Optional `prompt` (e.g. `login`) is forwarded to the issuer so leftover
+    RodiumAi cookies cannot silently approve the wrong identity.
     """
     locale = resolve_locale(request)
     settings = get_settings()
     if not settings.rodium_oidc_client_id:
         raise HTTPException(status_code=503, detail=t("rodium_oauth_not_configured", locale))
     binding = (request.query_params.get("state_binding") or "").strip() or None
+    prompt = (request.query_params.get("prompt") or "").strip() or None
     try:
         verifier, challenge = generate_pkce()
         state = create_oauth_state(verifier, binding)
-        url = build_authorize_url(state=state, code_challenge=challenge)
+        url = build_authorize_url(state=state, code_challenge=challenge, prompt=prompt)
     except RodiumOidcError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     return OAuthStartResponse(authorize_url=url)
@@ -319,6 +323,7 @@ async def rodium_account(
 ) -> RodiumAccountOut:
     if not user.rodium_sub:
         return RodiumAccountOut(linked=False)
+    locale = resolve_locale(request)
     row = _get_or_create_settings(db, user)
     # Prefer DB cache so navbar/profile never wait on Nest latency.
     keys: list = []
@@ -342,6 +347,7 @@ async def rodium_account(
     # does not stick on the login-time balance.
     fresh = (request.query_params.get("fresh") or "").lower() in ("1", "true", "yes")
     timeout_s = 8.0 if fresh else 2.5
+    live_ok = False
 
     try:
         async with asyncio.timeout(timeout_s):
@@ -353,9 +359,39 @@ async def rodium_account(
             row.rodium_api_keys_json = json.dumps(keys)
             row.rodium_wallet_json = json.dumps(wallet)
             db.commit()
+            live_ok = True
     except Exception:
-        # Keep cached keys/wallet for UI continuity.
-        pass
+        # Tokens missing after logout, or Nest blip — try a trusted reissue
+        # before falling back to the stale DB cache.
+        try:
+            access = await _reissue_rodium_tokens(db, user)
+            if access:
+                async with asyncio.timeout(timeout_s):
+                    live_keys = await fetch_api_keys(access)
+                    live_wallet = await fetch_wallet(access)
+                    keys = live_keys if isinstance(live_keys, list) else keys
+                    wallet = live_wallet if isinstance(live_wallet, dict) else wallet
+                    row.rodium_api_keys_json = json.dumps(keys)
+                    row.rodium_wallet_json = json.dumps(wallet)
+                    db.commit()
+                    live_ok = True
+        except Exception:
+            pass
+
+    if not live_ok and fresh and not wallet:
+        # Last resort: pasted API key path (manual key users).
+        try:
+            from app.services.rodium import fetch_wallet_balance_by_api_key
+
+            if row.rodium_api_key_encrypted:
+                api_key = decrypt_secret(row.rodium_api_key_encrypted)
+                live_wallet = await fetch_wallet_balance_by_api_key(api_key, locale)
+                if isinstance(live_wallet, dict):
+                    wallet = live_wallet
+                    row.rodium_wallet_json = json.dumps(wallet)
+                    db.commit()
+        except Exception:
+            pass
 
     if not has_generation_key(user, row) and keys:
         await _ensure_default_generation_key(db, user, row, keys if isinstance(keys, list) else [])
@@ -485,6 +521,42 @@ async def _link_rodium_account(db: Session, user: User) -> str | None:
     return str(result.tokens.get("access_token") or "") or None
 
 
+async def _reissue_rodium_tokens(db: Session, user: User) -> str | None:
+    """Restore OAuth tokens for an already-linked account after Forge logout.
+
+    Logout clears refresh tokens but keeps `rodium_sub`. Google/email login
+    proves the address again; Nest re-mints tokens only when `userId` matches.
+    """
+    if not user.rodium_sub or not rodium_provisioning.enabled():
+        return None
+    row = _get_or_create_settings(db, user)
+    if row.rodium_refresh_token_encrypted:
+        return None
+    result = await rodium_provisioning.reissue_tokens(
+        email=user.email, user_id=str(user.rodium_sub)
+    )
+    if result is None:
+        return None
+    _store_oauth_tokens(row, result.tokens)
+    if not row.rodium_api_key_hint:
+        row.rodium_api_key_hint = "RodiumAi account"
+    db.commit()
+    return str(result.tokens.get("access_token") or "") or None
+
+
+async def _ensure_rodium_tokens_after_login(
+    db: Session, user: User, background_tasks: BackgroundTasks
+) -> None:
+    """Provision or reissue RodiumAi tokens, then hydrate wallet/keys off-request."""
+    access = await _link_rodium_account(db, user)
+    db.refresh(user)
+    if not access:
+        access = await _reissue_rodium_tokens(db, user)
+        db.refresh(user)
+    if access:
+        background_tasks.add_task(_hydrate_rodium_account_cache, user.id, access)
+
+
 def _send_verification_email(db: Session, user: User, locale: str) -> None:
     """Issue a fresh verification link and mail it.
 
@@ -564,14 +636,7 @@ async def verify_email(
     db.commit()
     db.refresh(user)
 
-    access = await _link_rodium_account(db, user)
-    db.refresh(user)
-    if access:
-        # Keys and wallet hydrate after the response, same as the OIDC callback:
-        # the user should land in the builder, not wait on two extra round-trips.
-        # This is also what mints and selects their generation key, via
-        # `autoGenerateApiKey` on the platform side.
-        background_tasks.add_task(_hydrate_rodium_account_cache, user.id, access)
+    await _ensure_rodium_tokens_after_login(db, user, background_tasks)
 
     return TokenResponse(access_token=token_for_user(user), email_verified=True)
 
@@ -766,16 +831,18 @@ async def oauth_firebase(
             detail=t("email_not_verified", locale),
         )
 
-    access = await _link_rodium_account(db, user)
-    db.refresh(user)
-    if access:
-        background_tasks.add_task(_hydrate_rodium_account_cache, user.id, access)
+    await _ensure_rodium_tokens_after_login(db, user, background_tasks)
 
     return TokenResponse(access_token=token_for_user(user), email_verified=True)
 
 
 @router.post("/login", response_model=TokenResponse)
-def login(body: LoginRequest, request: Request, db: Session = Depends(get_db)) -> TokenResponse:
+async def login(
+    body: LoginRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+) -> TokenResponse:
     locale = resolve_locale(request)
     rate_limit.enforce(request, "login", limit=10, window_seconds=900)
 
@@ -796,6 +863,7 @@ def login(body: LoginRequest, request: Request, db: Session = Depends(get_db)) -
             status_code=status.HTTP_403_FORBIDDEN,
             detail=t("email_not_verified", locale),
         )
+    await _ensure_rodium_tokens_after_login(db, user, background_tasks)
     return TokenResponse(
         access_token=token_for_user(user),
         email_verified=user.email_verified_at is not None,
@@ -862,6 +930,9 @@ async def logout(
         row.rodium_access_token_encrypted = None
         row.rodium_refresh_token_encrypted = None
         row.rodium_token_expires_at = None
+        # Drop the cached balance so a later Google login cannot show a stale
+        # figure while live Nest fetch is still re-linking tokens.
+        row.rodium_wallet_json = None
         db.commit()
     return LogoutResponse()
 

--- a/apps/api/app/services/rodium_oidc.py
+++ b/apps/api/app/services/rodium_oidc.py
@@ -90,7 +90,12 @@ def parse_oauth_state(state: str, binding: str | None = None) -> str:
     return verifier
 
 
-def build_authorize_url(*, state: str, code_challenge: str) -> str:
+def build_authorize_url(
+    *,
+    state: str,
+    code_challenge: str,
+    prompt: str | None = None,
+) -> str:
     settings = get_settings()
     if not settings.rodium_oidc_client_id or not settings.rodium_oidc_redirect_uri:
         raise RodiumOidcError("RodiumAi OAuth is not configured on the Forge API")
@@ -103,6 +108,11 @@ def build_authorize_url(*, state: str, code_challenge: str) -> str:
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
     }
+    # Interactive prompts disable Nest's silent first-party approve so a leftover
+    # RodiumAi cookie cannot bind the wrong Forge session.
+    cleaned = (prompt or "").strip().lower()
+    if cleaned and cleaned != "none":
+        params["prompt"] = cleaned
     return f"{settings.rodium_oidc_authorize_url}?{urlencode(params)}"
 
 

--- a/apps/api/app/services/rodium_provisioning.py
+++ b/apps/api/app/services/rodium_provisioning.py
@@ -119,3 +119,66 @@ async def provision(
         return None
 
     return ProvisionResult(user_id=user_id, tokens=tokens)
+
+
+async def reissue_tokens(
+    *,
+    email: str,
+    user_id: str,
+) -> ProvisionResult | None:
+    """Re-mint OAuth tokens for an account Forge already linked.
+
+    Used after logout cleared refresh tokens: Google/email sign-in proves the
+    address again, and we pass the stored `rodium_sub` so Nest refuses a
+    mismatch.
+    """
+    settings = get_settings()
+    if not settings.provisioning_enabled or not settings.rodium_oidc_client_id:
+        return None
+
+    url = settings.rodium_provisioning_url.rstrip("/")
+    if url.endswith("/users"):
+        url = f"{url}/reissue-tokens"
+    else:
+        url = f"{url}/users/reissue-tokens"
+
+    payload = {
+        "email": email,
+        "emailVerified": True,
+        "userId": user_id,
+        "clientId": settings.rodium_oidc_client_id,
+        "source": "forge",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=PROVISION_TIMEOUT) as client:
+            response = await client.post(
+                url,
+                json=payload,
+                headers={"X-Internal-Token": settings.rodium_provision_token},
+            )
+    except httpx.HTTPError:
+        logger.warning("rodium.reissue.unreachable", exc_info=True)
+        return None
+
+    if response.status_code >= 400:
+        logger.warning(
+            "rodium.reissue.rejected status=%s body=%s",
+            response.status_code,
+            response.text[:300],
+        )
+        return None
+
+    try:
+        data = response.json()
+        uid = str(data["userId"])
+        tokens = {
+            "access_token": data["accessToken"],
+            "refresh_token": data["refreshToken"],
+            "expires_in": data.get("expiresIn"),
+        }
+    except (ValueError, KeyError):
+        logger.warning("rodium.reissue.malformed_response", exc_info=True)
+        return None
+
+    return ProvisionResult(user_id=uid, tokens=tokens)

--- a/apps/web/app/auth/rodium-popup/page.tsx
+++ b/apps/web/app/auth/rodium-popup/page.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Suspense, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 
 import { AuthCallbackScreen } from "@/components/auth/AuthCallbackScreen";
 import { beginRodiumOAuthInPopup } from "@/lib/rodium-oauth";
@@ -15,14 +16,16 @@ import { useI18n } from "@/lib/i18n/I18nProvider";
 
 function RodiumPopupInner() {
   const { t } = useI18n();
+  const params = useSearchParams();
   const [error, setError] = useState<string | null>(null);
   const startedRef = useRef(false);
 
   useEffect(() => {
     if (startedRef.current) return;
     startedRef.current = true;
+    const prompt = params.get("prompt") || "login";
 
-    void beginRodiumOAuthInPopup().then((result) => {
+    void beginRodiumOAuthInPopup({ prompt }).then((result) => {
       if (result.ok) return;
       if (result.reason === "oidc_unavailable") {
         setError(t("loginRodiumOidcUnavailable"));
@@ -32,7 +35,7 @@ function RodiumPopupInner() {
         result.error instanceof Error ? result.error.message : t("errorGeneric"),
       );
     });
-  }, [t]);
+  }, [params, t]);
 
   return (
     <AuthCallbackScreen

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -22,8 +22,9 @@ import { AuthCallbackScreen } from "@/components/auth/AuthCallbackScreen";
 import { CheckInboxNotice } from "@/components/auth/CheckInboxNotice";
 import { PasswordField } from "@/components/auth/PasswordField";
 import { SocialButtons } from "@/components/auth/SocialButtons";
-import { ApiError, api, getToken, setToken } from "@/lib/api";
+import { ApiError, api, setToken } from "@/lib/api";
 import { sanitizeReturnTo, startRodiumOAuth } from "@/lib/rodium-oauth";
+import { clearSessionCache } from "@/lib/session-cache";
 import { firebaseEnabled } from "@/lib/firebase";
 import { useI18n } from "@/lib/i18n/I18nProvider";
 
@@ -64,6 +65,9 @@ function LoginInner() {
       returnTo: sanitizeReturnTo(params.get("next")),
       unavailableHref: null,
       mode: autostart ? "redirect" : "popup",
+      // Autostart: silent SSO with the dashboard cookie. Manual: force login
+      // so a leftover RodiumAi session cannot bind the wrong Forge account.
+      prompt: autostart ? null : "login",
     });
     if (result.ok) {
       // Popup mode navigates the opener; redirect mode leaves this page.
@@ -112,10 +116,11 @@ function LoginInner() {
   useEffect(() => {
     if (!autostart || startedRef.current) return;
     startedRef.current = true;
-    if (getToken()) {
-      router.replace("/dashboard");
-      return;
-    }
+    // Dashboard CTA must always run OIDC for the *current* RodiumAi session.
+    // Keeping an existing forge_token short-circuits to the previous Forge
+    // account and ignores the account just opened on rodiumai.io.
+    setToken(null);
+    clearSessionCache();
     void loginWithRodium();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot autostart
   }, [autostart, router]);

--- a/apps/web/lib/rodium-oauth.test.ts
+++ b/apps/web/lib/rodium-oauth.test.ts
@@ -100,7 +100,7 @@ describe("startRodiumOAuth popup", () => {
     const result = await startRodiumOAuth({ returnTo: "/dashboard", mode: "popup" });
     expect(result).toEqual({ ok: false, reason: "popup_blocked" });
     expect(window.open).toHaveBeenCalledWith(
-      "/auth/rodium-popup",
+      "/auth/rodium-popup?prompt=login",
       OAUTH_POPUP_WINDOW_NAME,
       expect.stringContaining("width=520"),
     );

--- a/apps/web/lib/rodium-oauth.ts
+++ b/apps/web/lib/rodium-oauth.ts
@@ -127,12 +127,13 @@ export type StartRodiumOAuthResult =
 
 async function startRodiumOAuthRedirect(options?: {
   unavailableHref?: string | null;
+  prompt?: string | null;
 }): Promise<StartRodiumOAuthResult> {
   try {
     const binding = await createStateBinding();
-    const data = await api<{ authorize_url: string }>(
-      `/auth/rodium/start?state_binding=${encodeURIComponent(binding)}`,
-    );
+    const qs = new URLSearchParams({ state_binding: binding });
+    if (options?.prompt) qs.set("prompt", options.prompt);
+    const data = await api<{ authorize_url: string }>(`/auth/rodium/start?${qs}`);
     window.location.href = data.authorize_url;
     return { ok: true, mode: "redirect" };
   } catch (err) {
@@ -221,16 +222,28 @@ export async function startRodiumOAuth(options?: {
   unavailableHref?: string | null;
   /** Default `popup`. Use `redirect` for `?autostart=1`. */
   mode?: "popup" | "redirect";
+  /**
+   * OIDC `prompt`. Manual Continue uses `login` so a leftover RodiumAi cookie
+   * cannot silently approve. Autostart omits it (SSO with the dashboard session).
+   */
+  prompt?: string | null;
 }): Promise<StartRodiumOAuthResult> {
   stashOAuthReturnTo(options?.returnTo);
   const mode = options?.mode ?? "popup";
+  const prompt =
+    options && "prompt" in options
+      ? options.prompt
+      : mode === "popup"
+        ? "login"
+        : null;
 
   if (mode === "redirect") {
-    return startRodiumOAuthRedirect(options);
+    return startRodiumOAuthRedirect({ ...options, prompt });
   }
 
+  const popupQs = prompt ? `?prompt=${encodeURIComponent(prompt)}` : "";
   const popup = window.open(
-    "/auth/rodium-popup",
+    `/auth/rodium-popup${popupQs}`,
     OAUTH_POPUP_WINDOW_NAME,
     popupFeatures(),
   );
@@ -256,7 +269,9 @@ export async function startRodiumOAuth(options?: {
  * Kick off OIDC *inside* the popup window (create binding → authorize URL).
  * Called only from `/auth/rodium-popup`.
  */
-export async function beginRodiumOAuthInPopup(): Promise<
+export async function beginRodiumOAuthInPopup(options?: {
+  prompt?: string | null;
+}): Promise<
   { ok: true } | { ok: false; reason: "oidc_unavailable" | "error"; error?: unknown }
 > {
   try {
@@ -266,9 +281,10 @@ export async function beginRodiumOAuthInPopup(): Promise<
   }
   try {
     const binding = await createStateBinding();
-    const data = await api<{ authorize_url: string }>(
-      `/auth/rodium/start?state_binding=${encodeURIComponent(binding)}`,
-    );
+    const qs = new URLSearchParams({ state_binding: binding });
+    const prompt = options?.prompt ?? "login";
+    if (prompt) qs.set("prompt", prompt);
+    const data = await api<{ authorize_url: string }>(`/auth/rodium/start?${qs}`);
     window.location.href = data.authorize_url;
     return { ok: true };
   } catch (err) {

--- a/apps/web/lib/session-cache.ts
+++ b/apps/web/lib/session-cache.ts
@@ -153,7 +153,7 @@ export async function ensureSession(options?: { force?: boolean }): Promise<Sess
         api<{
           linked: boolean;
           wallet?: SessionWallet | null;
-        }>("/auth/rodium/account"),
+        }>(options?.force ? "/auth/rodium/account?fresh=1" : "/auth/rodium/account"),
       ]);
 
       const prev = getSessionSnapshot();


### PR DESCRIPTION
## Summary
Corrige les deux bugs de session rapportés sur Forge :

1. **Wallet stale après recharge / logout Google** — logout effaçait les tokens OAuth sans les restaurer au relogin, et le cache `rodium_wallet_json` continuait d’être servi. Désormais : clear du cache wallet au logout, reissue Nest des tokens si `rodium_sub` est déjà lié, `fresh=1` sur `ensureSession({ force })`.
2. **Mauvais compte au CTA dashboard / Continue** — `autostart=1` court-circuitait vers le dashboard si `forge_token` existait. On clear la session Forge avant OIDC. Le bouton manuel envoie `prompt=login` (Nest ignore le silent approve).

À merger avec [nestjs#85](https://github.com/RodiumAi/rodiumai_backend_nestjs/pull/85) (endpoint `reissue-tokens` + honor `prompt`).

## Test plan
- [ ] CI Forge verte
- [ ] Deploy Nest #85 avant ou avec Forge
- [ ] Compte Google : recharge sur RodiumAi → refresh Forge montre le nouveau solde
- [ ] Logout Forge + Google login → solde live
- [ ] Forge loggé A, RodiumAi B, clic Forge → session B
- [ ] Continue with RodiumAi → login/consent (pas silent SSO fantôme)

Made with [Cursor](https://cursor.com)