### PR TITLE
fix(api): ruff SIM108 blocking Deploy API

### DIFF
--- a/apps/api/app/services/rodium_provisioning.py
+++ b/apps/api/app/services/rodium_provisioning.py
@@ -137,10 +137,11 @@ async def reissue_tokens(
         return None
 
     url = settings.rodium_provisioning_url.rstrip("/")
-    if url.endswith("/users"):
-        url = f"{url}/reissue-tokens"
-    else:
-        url = f"{url}/users/reissue-tokens"
+    url = (
+        f"{url}/reissue-tokens"
+        if url.endswith("/users")
+        else f"{url}/users/reissue-tokens"
+    )
 
     payload = {
         "email": email,


### PR DESCRIPTION
## Summary
- Fix ruff SIM108 on reissue-tokens URL so Deploy API can pass pre-deploy checks after #75.

## Test plan
- [ ] Deploy API workflow succeeds on main
- [ ] forge-api ECS rolls a new task