### PR TITLE
fix(api): restore encrypt when ENCRYPTION_KEY is not Fernet

### DIFF
--- a/apps/api/app/crypto.py
+++ b/apps/api/app/crypto.py
@@ -6,6 +6,11 @@ from cryptography.fernet import Fernet, InvalidToken
 from app.config import get_settings
 
 
+def _fernet_from_material(material: str) -> Fernet:
+    digest = hashlib.sha256(material.encode("utf-8")).digest()
+    return Fernet(base64.urlsafe_b64encode(digest))
+
+
 def _fernet() -> Fernet:
     settings = get_settings()
     raw = (settings.encryption_key or "").strip()
@@ -14,14 +19,14 @@ def _fernet() -> Fernet:
             key = raw.encode("utf-8") if isinstance(raw, str) else raw
             return Fernet(key)
         except Exception:
-            pass
-    # No valid explicit ENCRYPTION_KEY. Deriving one from SECRET_KEY is only
-    # acceptable locally; anywhere else the SECRET_KEY may be a public default,
-    # which would leave stored API keys / refresh tokens readable.
+            # Prod historically stored a random/hex string in ENCRYPTION_KEY,
+            # not a Fernet key. Derive so existing ciphertext stays readable.
+            return _fernet_from_material(raw)
+    # Empty ENCRYPTION_KEY: deriving from SECRET_KEY is only acceptable locally;
+    # elsewhere SECRET_KEY may be a public default.
     if not settings.is_local:
         raise RuntimeError("ENCRYPTION_KEY is required (a valid Fernet key) outside local environments")
-    digest = hashlib.sha256((raw or settings.secret_key).encode("utf-8")).digest()
-    return Fernet(base64.urlsafe_b64encode(digest))
+    return _fernet_from_material(settings.secret_key)
 
 
 def encrypt_secret(plain: str) -> str:

--- a/apps/api/tests/test_crypto.py
+++ b/apps/api/tests/test_crypto.py
@@ -1,0 +1,53 @@
+"""Encryption key resolution for local vs staging-shaped ENCRYPTION_KEY values."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.config import get_settings
+from app import crypto
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_non_fernet_encryption_key_derives_like_legacy(monkeypatch):
+    material = "a" * 64
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.setenv("ENCRYPTION_KEY", material)
+    monkeypatch.setenv("SECRET_KEY", "staging-secret-not-the-default-value-xxxxx")
+    get_settings.cache_clear()
+
+    expected = Fernet(base64.urlsafe_b64encode(hashlib.sha256(material.encode()).digest()))
+    token = crypto.encrypt_secret("hello-forge")
+    assert expected.decrypt(token.encode()).decode() == "hello-forge"
+    assert crypto.decrypt_secret(token) == "hello-forge"
+
+
+def test_valid_fernet_encryption_key_used_as_is(monkeypatch):
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.setenv("ENCRYPTION_KEY", key)
+    monkeypatch.setenv("SECRET_KEY", "staging-secret-not-the-default-value-xxxxx")
+    get_settings.cache_clear()
+
+    token = crypto.encrypt_secret("direct-key")
+    assert Fernet(key.encode()).decrypt(token.encode()).decode() == "direct-key"
+
+
+def test_missing_encryption_key_fails_outside_local(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.setenv("ENCRYPTION_KEY", "")
+    monkeypatch.setenv("SECRET_KEY", "staging-secret-not-the-default-value-xxxxx")
+    get_settings.cache_clear()
+
+    with pytest.raises(RuntimeError, match="ENCRYPTION_KEY"):
+        crypto.encrypt_secret("nope")


### PR DESCRIPTION
## Summary
- Prod/staging `ENCRYPTION_KEY` is a 64-char material string, not a Fernet key.
- Harden change required a valid Fernet key → every auth encrypt (Google / Rodium callback) returned 500 → browser « network error ».
- Derive via sha256 when the value is present but not Fernet-shaped (legacy ciphertext stays readable). Still fail if empty outside local.

## Test plan
- [x] `pytest tests/test_crypto.py`
- [ ] Google login on https://forge.rodiumai.io/login
- [ ] Continue with RodiumAi callback